### PR TITLE
docs: add jov-cli as community CLI tool for Jupiter APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,25 @@ npx add-skill jup-ag/agents-skills --skill "integrating-jupiter"
 npx add-skill jup-ag/agents-skills
 ```
 
+## Community Tools
+
+### jov-cli
+
+CLI wrapper for all 15 Jupiter APIs. Swap, lend, DCA, limit orders, price feeds, portfolio, token search — one command each.
+```bash
+npm install -g jovebot
+jovebot price SOL ETH BTC
+jovebot swap SOL USDC 2.0
+jovebot lend pools
+jovebot trigger create USDC SOL 150 1.0
+jovebot dca create USDC SOL 1000 10 daily
+jovebot tokens trending
+jovebot portfolio
+jovebot doctor
+```
+
+Source: [github.com/J0VEBOT/jov-cli](https://github.com/J0VEBOT/jov-cli)
+
 ## License
 
 MIT


### PR DESCRIPTION
## What
Added jov-cli as a community CLI tool reference — wraps all 15 Jupiter APIs into simple terminal commands.

## Why
Jupiter doesn't have an official CLI. jov-cli fills that gap — one command per API (swap, lend, DCA, trigger, price, tokens, portfolio).

## Link
https://github.com/J0VEBOT/jov-cli