### PR TITLE
Clarify auth tiers: keyless reads work without x-api-key

### DIFF
--- a/skills/integrating-jupiter/SKILL.md
+++ b/skills/integrating-jupiter/SKILL.md
@@ -39,7 +39,10 @@ tags:
 Single skill for all Jupiter APIs, optimized for fast routing and deterministic execution.
 
 **Base URL**: `https://api.jup.ag`
-**Auth**: `x-api-key` from [portal.jup.ag](https://portal.jup.ag/) (**required for Jupiter REST endpoints**)
+
+**Auth**:
+- **Read endpoints** (e.g. `/lend/v1/earn/tokens`, `/prediction/v1/events`, `/prediction/v1/markets/{id}`, `/prediction/v1/orderbook/{id}`): keyless at 0.5 RPS works — useful for prototyping and discovery.
+- **Write endpoints** (e.g. `POST /prediction/v1/orders`, swap quote/build, transaction crafting) and **higher rate limits**: require `x-api-key` from [portal.jup.ag](https://portal.jup.ag/).
 
 ## Use/Do Not Use
 


### PR DESCRIPTION
## What

Replace the blanket "auth required for Jupiter REST endpoints" sentence in `integrating-jupiter/SKILL.md` with a tiered description that distinguishes keyless reads from authenticated writes.

## Why

SKILL.md content is auto-loaded into agent context (Claude Code, Cursor, etc.) and read as a runtime instruction. The current line:

> **Auth**: `x-api-key` from [portal.jup.ag](https://portal.jup.ag/) (**required for Jupiter REST endpoints**)

overstates the requirement. Keyless 0.5 RPS works on the read endpoints we touched while building a hackathon project on Jupiter Prediction + Lend Earn. Confirmed empirically:

- `GET /lend/v1/earn/tokens` → 200, returned 5 tokens (USDC, USDT, SOL, EURC, JUICED)
- `GET /prediction/v1/events?category=crypto` → 200, returned 4054 events
- `GET /prediction/v1/markets/{id}` → 200
- `GET /prediction/v1/orderbook/{id}` → 200

The convention in https://dev.jup.ag/docs/llms.txt already documents keyless access correctly — this brings the SKILL.md into alignment with that source of truth.

## Effect

Agents reading the SKILL.md verbatim during prototyping no longer fail-fast on missing API keys for read-only exploration. Authenticated tiers remain accurately described for write paths.

## Context

This came out of a Solana Frontier hackathon project (Jupiter sidetrack). Full DX report: https://github.com/criptocbas/Ballast/blob/main/DX-REPORT.md — the fix here is captured as `DX-GAP-#13` in that report, alongside 26 other findings.

Happy to iterate on phrasing or formatting (e.g. a table instead of bullets, additional endpoints listed) if a different style fits the repo's conventions better.
