### PR TITLE
chore: migrate portal.jup.ag to developers.jup.ag

### DIFF
--- a/.plugins/integrate-jupiter/claude/skills/integrating-jupiter/SKILL.md
+++ b/.plugins/integrate-jupiter/claude/skills/integrating-jupiter/SKILL.md
@@ -4,7 +4,7 @@ description: Comprehensive guidance for integrating Jupiter APIs (Swap, Lend, Pe
 license: MIT
 metadata:
   author: jup-ag
-  version: "1.0.0"
+  version: "1.0.1"
 tags:
   - jupiter
   - jup-ag
@@ -39,7 +39,7 @@ tags:
 Single skill for all Jupiter APIs, optimized for fast routing and deterministic execution.
 
 **Base URL**: `https://api.jup.ag`
-**Auth**: `x-api-key` from [portal.jup.ag](https://portal.jup.ag/) (**required for Jupiter REST endpoints**)
+**Auth**: `x-api-key` from [developers.jup.ag](https://developers.jup.ag/) (**required for Jupiter REST endpoints**)
 
 ## Use/Do Not Use
 
@@ -60,7 +60,7 @@ Do not use when:
 ```typescript
 import { Connection, Keypair, VersionedTransaction } from '@solana/web3.js';
 
-const API_KEY = process.env.JUPITER_API_KEY!;  // from portal.jup.ag
+const API_KEY = process.env.JUPITER_API_KEY!;  // from developers.jup.ag
 if (!API_KEY) throw new Error('Missing JUPITER_API_KEY');
 const BASE = 'https://api.jup.ag';
 const headers = { 'x-api-key': API_KEY };

--- a/.plugins/integrate-jupiter/claude/skills/jupiter-swap-migration/SKILL.md
+++ b/.plugins/integrate-jupiter/claude/skills/jupiter-swap-migration/SKILL.md
@@ -4,7 +4,7 @@ description: Migration guide from Jupiter Metis (v1) or Ultra to Swap API v2. Us
 license: MIT
 metadata:
   author: jup-ag
-  version: "1.0.0"
+  version: "1.0.1"
 tags:
   - jupiter
   - swap-migration
@@ -19,7 +19,7 @@ tags:
 Migrate existing Jupiter swap integrations from **Metis (v1)** or **Ultra** to the unified **Swap API v2**.
 
 **Target Base URL**: `https://api.jup.ag/swap/v2`
-**Auth**: `x-api-key` from [portal.jup.ag](https://portal.jup.ag/) (unchanged)
+**Auth**: `x-api-key` from [developers.jup.ag](https://developers.jup.ag/) (unchanged)
 
 ## Use/Do Not Use
 

--- a/.plugins/integrate-jupiter/claude/skills/jupiter-vrfd/SKILL.md
+++ b/.plugins/integrate-jupiter/claude/skills/jupiter-vrfd/SKILL.md
@@ -4,7 +4,7 @@ description: Use when a user mentions Jupiter token verification, VRFD eligibili
 license: MIT
 metadata:
   author: jup-ag
-  version: "1.0.0"
+  version: "1.0.1"
 tags:
   - jupiter
   - jup-ag
@@ -19,7 +19,7 @@ tags:
 This skill routes agents through the public Jupiter token-verification flow for a Solana token mint.
 
 **Base URL**: `https://api.jup.ag`
-**Auth**: `x-api-key` from [portal.jup.ag](https://portal.jup.ag/) (required)
+**Auth**: `x-api-key` from [developers.jup.ag](https://developers.jup.ag/) (required)
 **Cost**: 1000 JUP
 
 ## Use/Do Not Use

--- a/.plugins/integrate-jupiter/claude/skills/jupiter-vrfd/examples/verify.md
+++ b/.plugins/integrate-jupiter/claude/skills/jupiter-vrfd/examples/verify.md
@@ -10,7 +10,7 @@ import { Keypair, VersionedTransaction } from '@solana/web3.js';
 import bs58 from 'bs58';
 
 const BASE = 'https://api.jup.ag';
-const API_KEY = process.env.JUPITER_API_KEY!; // from portal.jup.ag
+const API_KEY = process.env.JUPITER_API_KEY!; // from developers.jup.ag
 
 async function jupiterFetch<T>(path: string, init?: RequestInit): Promise<T> {
   const res = await fetch(`${BASE}${path}`, {

--- a/.plugins/integrate-jupiter/claude/skills/jupiter-vrfd/references/api-reference.md
+++ b/.plugins/integrate-jupiter/claude/skills/jupiter-vrfd/references/api-reference.md
@@ -1,7 +1,7 @@
 # API Reference — Jupiter Token Verification
 
 > **Base URL**: `https://api.jup.ag`
-> **Auth**: `x-api-key` header from [portal.jup.ag](https://portal.jup.ag/) (required for all requests)
+> **Auth**: `x-api-key` header from [developers.jup.ag](https://developers.jup.ag/) (required for all requests)
 
 This reference intentionally documents only the 3 public routes used by the skill.
 

--- a/.plugins/integrate-jupiter/codex/skills/integrating-jupiter/SKILL.md
+++ b/.plugins/integrate-jupiter/codex/skills/integrating-jupiter/SKILL.md
@@ -4,7 +4,7 @@ description: Comprehensive guidance for integrating Jupiter APIs (Swap, Lend, Pe
 license: MIT
 metadata:
   author: jup-ag
-  version: "1.0.0"
+  version: "1.0.1"
 tags:
   - jupiter
   - jup-ag
@@ -39,7 +39,7 @@ tags:
 Single skill for all Jupiter APIs, optimized for fast routing and deterministic execution.
 
 **Base URL**: `https://api.jup.ag`
-**Auth**: `x-api-key` from [portal.jup.ag](https://portal.jup.ag/) (**required for Jupiter REST endpoints**)
+**Auth**: `x-api-key` from [developers.jup.ag](https://developers.jup.ag/) (**required for Jupiter REST endpoints**)
 
 ## Use/Do Not Use
 
@@ -60,7 +60,7 @@ Do not use when:
 ```typescript
 import { Connection, Keypair, VersionedTransaction } from '@solana/web3.js';
 
-const API_KEY = process.env.JUPITER_API_KEY!;  // from portal.jup.ag
+const API_KEY = process.env.JUPITER_API_KEY!;  // from developers.jup.ag
 if (!API_KEY) throw new Error('Missing JUPITER_API_KEY');
 const BASE = 'https://api.jup.ag';
 const headers = { 'x-api-key': API_KEY };

--- a/.plugins/integrate-jupiter/codex/skills/jupiter-swap-migration/SKILL.md
+++ b/.plugins/integrate-jupiter/codex/skills/jupiter-swap-migration/SKILL.md
@@ -4,7 +4,7 @@ description: Migration guide from Jupiter Metis (v1) or Ultra to Swap API v2. Us
 license: MIT
 metadata:
   author: jup-ag
-  version: "1.0.0"
+  version: "1.0.1"
 tags:
   - jupiter
   - swap-migration
@@ -19,7 +19,7 @@ tags:
 Migrate existing Jupiter swap integrations from **Metis (v1)** or **Ultra** to the unified **Swap API v2**.
 
 **Target Base URL**: `https://api.jup.ag/swap/v2`
-**Auth**: `x-api-key` from [portal.jup.ag](https://portal.jup.ag/) (unchanged)
+**Auth**: `x-api-key` from [developers.jup.ag](https://developers.jup.ag/) (unchanged)
 
 ## Use/Do Not Use
 

--- a/.plugins/integrate-jupiter/codex/skills/jupiter-vrfd/SKILL.md
+++ b/.plugins/integrate-jupiter/codex/skills/jupiter-vrfd/SKILL.md
@@ -4,7 +4,7 @@ description: Use when a user mentions Jupiter token verification, VRFD eligibili
 license: MIT
 metadata:
   author: jup-ag
-  version: "1.0.0"
+  version: "1.0.1"
 tags:
   - jupiter
   - jup-ag
@@ -19,7 +19,7 @@ tags:
 This skill routes agents through the public Jupiter token-verification flow for a Solana token mint.
 
 **Base URL**: `https://api.jup.ag`
-**Auth**: `x-api-key` from [portal.jup.ag](https://portal.jup.ag/) (required)
+**Auth**: `x-api-key` from [developers.jup.ag](https://developers.jup.ag/) (required)
 **Cost**: 1000 JUP
 
 ## Use/Do Not Use

--- a/.plugins/integrate-jupiter/codex/skills/jupiter-vrfd/examples/verify.md
+++ b/.plugins/integrate-jupiter/codex/skills/jupiter-vrfd/examples/verify.md
@@ -10,7 +10,7 @@ import { Keypair, VersionedTransaction } from '@solana/web3.js';
 import bs58 from 'bs58';
 
 const BASE = 'https://api.jup.ag';
-const API_KEY = process.env.JUPITER_API_KEY!; // from portal.jup.ag
+const API_KEY = process.env.JUPITER_API_KEY!; // from developers.jup.ag
 
 async function jupiterFetch<T>(path: string, init?: RequestInit): Promise<T> {
   const res = await fetch(`${BASE}${path}`, {

--- a/.plugins/integrate-jupiter/codex/skills/jupiter-vrfd/references/api-reference.md
+++ b/.plugins/integrate-jupiter/codex/skills/jupiter-vrfd/references/api-reference.md
@@ -1,7 +1,7 @@
 # API Reference — Jupiter Token Verification
 
 > **Base URL**: `https://api.jup.ag`
-> **Auth**: `x-api-key` header from [portal.jup.ag](https://portal.jup.ag/) (required for all requests)
+> **Auth**: `x-api-key` header from [developers.jup.ag](https://developers.jup.ag/) (required for all requests)
 
 This reference intentionally documents only the 3 public routes used by the skill.
 

--- a/skills/integrating-jupiter/SKILL.md
+++ b/skills/integrating-jupiter/SKILL.md
@@ -39,7 +39,7 @@ tags:
 Single skill for all Jupiter APIs, optimized for fast routing and deterministic execution.
 
 **Base URL**: `https://api.jup.ag`
-**Auth**: `x-api-key` from [portal.jup.ag](https://portal.jup.ag/) (**required for Jupiter REST endpoints**)
+**Auth**: `x-api-key` from [developers.jup.ag](https://developers.jup.ag/) (**required for Jupiter REST endpoints**)
 
 ## Use/Do Not Use
 
@@ -60,7 +60,7 @@ Do not use when:
 ```typescript
 import { Connection, Keypair, VersionedTransaction } from '@solana/web3.js';
 
-const API_KEY = process.env.JUPITER_API_KEY!;  // from portal.jup.ag
+const API_KEY = process.env.JUPITER_API_KEY!;  // from developers.jup.ag
 if (!API_KEY) throw new Error('Missing JUPITER_API_KEY');
 const BASE = 'https://api.jup.ag';
 const headers = { 'x-api-key': API_KEY };

--- a/skills/jupiter-swap-migration/SKILL.md
+++ b/skills/jupiter-swap-migration/SKILL.md
@@ -19,7 +19,7 @@ tags:
 Migrate existing Jupiter swap integrations from **Metis (v1)** or **Ultra** to the unified **Swap API v2**.
 
 **Target Base URL**: `https://api.jup.ag/swap/v2`
-**Auth**: `x-api-key` from [portal.jup.ag](https://portal.jup.ag/) (unchanged)
+**Auth**: `x-api-key` from [developers.jup.ag](https://developers.jup.ag/) (unchanged)
 
 ## Use/Do Not Use
 

--- a/skills/jupiter-vrfd/SKILL.md
+++ b/skills/jupiter-vrfd/SKILL.md
@@ -4,7 +4,7 @@ description: Use when a user mentions Jupiter token verification, VRFD eligibili
 license: MIT
 metadata:
   author: jup-ag
-  version: "1.0.0"
+  version: "1.0.1"
 tags:
   - jupiter
   - jup-ag
@@ -19,7 +19,7 @@ tags:
 This skill routes agents through the public Jupiter token-verification flow for a Solana token mint.
 
 **Base URL**: `https://api.jup.ag`
-**Auth**: `x-api-key` from [portal.jup.ag](https://portal.jup.ag/) (required)
+**Auth**: `x-api-key` from [developers.jup.ag](https://developers.jup.ag/) (required)
 **Cost**: 1000 JUP
 
 ## Use/Do Not Use

--- a/skills/jupiter-vrfd/examples/verify.md
+++ b/skills/jupiter-vrfd/examples/verify.md
@@ -10,7 +10,7 @@ import { Keypair, VersionedTransaction } from '@solana/web3.js';
 import bs58 from 'bs58';
 
 const BASE = 'https://api.jup.ag';
-const API_KEY = process.env.JUPITER_API_KEY!; // from portal.jup.ag
+const API_KEY = process.env.JUPITER_API_KEY!; // from developers.jup.ag
 
 async function jupiterFetch<T>(path: string, init?: RequestInit): Promise<T> {
   const res = await fetch(`${BASE}${path}`, {

--- a/skills/jupiter-vrfd/references/api-reference.md
+++ b/skills/jupiter-vrfd/references/api-reference.md
@@ -1,7 +1,7 @@
 # API Reference — Jupiter Token Verification
 
 > **Base URL**: `https://api.jup.ag`
-> **Auth**: `x-api-key` header from [portal.jup.ag](https://portal.jup.ag/) (required for all requests)
+> **Auth**: `x-api-key` header from [developers.jup.ag](https://developers.jup.ag/) (required for all requests)
 
 This reference intentionally documents only the 3 public routes used by the skill.
 


### PR DESCRIPTION
## Summary

Replaces every `portal.jup.ag` reference across the skills with `developers.jup.ag`, the new resource users go to for API keys.

## Changes

- Update API key resource links in `integrating-jupiter`, `jupiter-swap-migration`, and `jupiter-vrfd` skills (root + mirrored copies under `.plugins/integrate-jupiter/{claude,codex}/`)
- Bump `jupiter-vrfd` skill version from `1.0.0` to `1.0.1`