### PR TITLE
docs: sync integrating-jupiter skills with current Jupiter docs (DEV-281)

### DIFF
--- a/.plugins/integrate-jupiter/claude/.claude-plugin/plugin.json
+++ b/.plugins/integrate-jupiter/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "integrate-jupiter",
   "description": "Jupiter integration and documentation skills for Solana, crypto, and finance workflows",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "Jupiter",
     "url": "https://jup.ag"

--- a/.plugins/integrate-jupiter/claude/.claude-plugin/plugin.json
+++ b/.plugins/integrate-jupiter/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "integrate-jupiter",
   "description": "Jupiter integration and documentation skills for Solana, crypto, and finance workflows",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": {
     "name": "Jupiter",
     "url": "https://jup.ag"

--- a/.plugins/integrate-jupiter/claude/skills/integrating-jupiter/README.md
+++ b/.plugins/integrate-jupiter/claude/skills/integrating-jupiter/README.md
@@ -20,7 +20,7 @@ Skills for AI coding agents in the Jupiter ecosystem.
 | Send | Token transfers via invite links |
 | Studio | Token creation with Dynamic Bonding Curves |
 | Lock | Token vesting and lock (on-chain program) |
-| Routing | DEX aggregation (Iris), RFQ (JupiterZ), and market listing |
+| Routing | DEX aggregation (Metis), RFQ (JupiterZ), and market listing |
 
 ## Examples
 
@@ -28,7 +28,7 @@ Production-ready code snippets in `examples/`:
 - `swap.md` — Swap order → sign → execute → confirm
 - `lend.md` — USDC deposit into Jupiter Lend
 - `trigger.md` — Create and execute a limit order
-- `price.md` — Multi-token price lookup with confidence filtering
+- `price.md` — Multi-token price lookup with fail-closed handling for unpriced mints
 
 ## Related skills
 

--- a/.plugins/integrate-jupiter/claude/skills/integrating-jupiter/SKILL.md
+++ b/.plugins/integrate-jupiter/claude/skills/integrating-jupiter/SKILL.md
@@ -4,7 +4,7 @@ description: Comprehensive guidance for integrating Jupiter APIs (Swap, Lend, Pe
 license: MIT
 metadata:
   author: jup-ag
-  version: "1.0.1"
+  version: "1.1.0"
 tags:
   - jupiter
   - jup-ag
@@ -27,7 +27,7 @@ tags:
   - jupiter-lock
   - jupiter-routing
   - jupiterz-rfq
-  - iris
+  - metis
   - jupiter-price-api
   - jupiter-tokens-api
   - jupiter-portal
@@ -131,11 +131,13 @@ Use each block as a minimal execution contract. Fetch the linked refs for full r
 - **Fee**: Variable by pair — 0 bps (Jupiter tokens/pegged), 2 bps (SOL-Stable), 5 bps (LST-Stable), 10 bps (most pairs), 50 bps (tokens < 24h). Referral fees: 50-255 bps (Jupiter retains 20%).
 - **Rate Limit**: 50 req/10s base, scales with 24h execute volume (see [Rate Limits](#rate-limits))
 - **Endpoints**: `/order` (GET), `/execute` (POST), `/build` (GET, Metis-only raw instructions)
-- **Routing**: 4 routers compete — Metis (API value: `iris`), JupiterZ (`jupiterz`), Dflow (`dflow`), OKX (`okx`). Response `mode` field: `"ultra"` (all routers, default params) or `"manual"` (restricted by optional params). `/build` uses Metis only.
-- **Gasless**: Three paths — automatic (Jupiter-covered), JupiterZ (MM-covered), integrator-payer (`payer` param, Metis-only routing). Eligibility varies by balance, trade size, and parameters used. See [Gasless docs](https://developers.jup.ag/docs/swap/v2/advanced/gasless.md) for current thresholds and disqualifying params.
-- **Gotchas**: Signed payloads have ~2 min TTL. Transactions are immutable after receipt. Split order/execute in code and logging. Re-quote before execution when conditions may have changed. `referralAccount`/`referralFee`/`receiver` disable JupiterZ only (Metis/Dflow/OKX remain). `payer` reduces routing to Metis only (per gasless docs; routing docs group all four as disabling JupiterZ but do not itemize the additional Dflow/OKX restriction). `/build` transactions cannot use `/execute` — self-manage via RPC.
+- **Routing**: 4 routers compete — Metis (`metis`), JupiterZ (`jupiterz`), Dflow (`dflow`), OKX (`okx`). The `router` response field returns one of these values (`metis`, not the legacy `iris`). `swapType` is `aggregator` (Metis, Dflow, or OKX) or `rfq` (JupiterZ). Response `mode` field: `"ultra"` (all routers, default params) or `"manual"` (restricted by optional params). `/build` uses Metis only.
+- **Gasless**: Three paths — automatic (Jupiter-covered), JupiterZ (MM-covered), integrator-payer (`payer` param, Metis-only routing). Eligibility varies by balance, trade size, and parameters used. See [Gasless docs](https://developers.jup.ag/docs/swap/advanced/gasless.md) for current thresholds and disqualifying params.
+- **Gotchas**: Signed payloads have ~2 min TTL. Transactions are immutable after receipt. Split order/execute in code and logging. Re-quote before execution when conditions may have changed. Routing impact of optional params: `referralAccount` + `referralFee` disable JupiterZ only (Metis/Dflow/OKX remain); `payer` (integrator gasless) restricts routing to Metis only (disables JupiterZ, Dflow, and OKX); `receiver` does NOT restrict routing, but must differ from `taker` (`receiver=taker` returns `400 "Receiver cannot be same as taker"`). `/build` transactions cannot use `/execute` — self-manage via RPC.
 - **Migrating from an older integration?** Use the `jupiter-swap-migration` skill.
-- Refs: [Overview](https://developers.jup.ag/docs/swap/index.md) | [Order & Execute](https://developers.jup.ag/docs/swap/v2/order-and-execute.md) | [Build](https://developers.jup.ag/docs/swap/v2/build/index.md) | [Fees](https://developers.jup.ag/docs/swap/v2/fees.md) | [Routing](https://developers.jup.ag/docs/swap/v2/routing.md) | [Gasless](https://developers.jup.ag/docs/swap/v2/advanced/gasless.md) | [Migration](https://developers.jup.ag/docs/swap/v2/migration.md) | [OpenAPI](https://developers.jup.ag/docs/openapi-spec/swap/v2/swap.yaml)
+- Refs: [Overview](https://developers.jup.ag/docs/swap/index.md) | [Order & Execute](https://developers.jup.ag/docs/swap/order-and-execute.md) | [Build](https://developers.jup.ag/docs/swap/build/index.md) | [Gasless](https://developers.jup.ag/docs/swap/advanced/gasless.md) | [Migration](https://developers.jup.ag/docs/swap/migration/ultra-to-order.md) | [OpenAPI](https://developers.jup.ag/docs/openapi-spec/swap/v2/swap.yaml)
+
+  Fees are documented inline on the Order & Execute and Build pages; router competition and the parameter routing-impact matrix are on the Overview and Order & Execute pages.
 
 Common error codes returned by `/swap/v2/execute` with recommended actions:
 
@@ -157,6 +159,8 @@ Common error codes returned by `/swap/v2/execute` with recommended actions:
 | `-2004` | RFQ | Swap rejected | Yes | Re-quote, possibly different route |
 | `429` | Rate limit | Rate limited | Yes | Exponential backoff, wait 10s window |
 
+On success, `/execute` returns `{ status: "Success", code: 0, signature, inputAmountResult, outputAmountResult, slot, totalInputAmount, totalOutputAmount }`. On failure it returns `status: "Failed"` with a non-zero `code` and an `error` string. `inputAmountResult`/`outputAmountResult` are the actual on-chain amounts; reconcile against your quote.
+
 
 ---
 
@@ -169,7 +173,7 @@ Common error codes returned by `/swap/v2/execute` with recommended actions:
 - **Endpoints**: `/earn/deposit` (POST), `/earn/withdraw` (POST), `/earn/mint` (POST), `/earn/redeem` (POST), `/earn/deposit-instructions` (POST), `/earn/withdraw-instructions` (POST), `/earn/tokens` (GET), `/earn/positions` (GET), `/earn/earnings` (GET)
 - **Gotchas**: Recompute account state before each state-changing action. Encode risk checks (health factors, liquidation boundaries) as preconditions. All deposit/withdraw/mint/redeem return base64 unsigned `VersionedTransaction`.
 - **For SDK-level integration** with `@jup-ag/lend` and `@jup-ag/lend-read`, use the `jupiter-lend` skill.
-- Refs: [Overview](https://developers.jup.ag/docs/lend/index.md) | [Earn](https://developers.jup.ag/docs/lend/earn.md) | [SDK](https://developers.jup.ag/docs/lend/sdk.md) | [OpenAPI](https://developers.jup.ag/docs/openapi-spec/lend/lend.yaml)
+- Refs: [Overview](https://developers.jup.ag/docs/lend/index.md) | [Earn](https://developers.jup.ag/docs/lend/earn.md) | [SDK](https://developers.jup.ag/docs/lend/api-vs-sdk.md) | [OpenAPI](https://developers.jup.ag/docs/openapi-spec/lend/lend.yaml)
 
 ---
 
@@ -192,8 +196,8 @@ Common error codes returned by `/swap/v2/execute` with recommended actions:
 - **Endpoints**: `/auth/challenge` (POST, body: `walletPubkey` + `type`), `/auth/verify` (POST, body: `type` + `walletPubkey` + base58 `signature`), `/vault` (GET), `/vault/register` (GET), `/deposit/craft` (POST), `/orders/price` (POST create, PATCH update), `/orders/price/cancel/{orderId}` (POST, initiates withdrawal), `/orders/price/confirm-cancel/{orderId}` (POST, submits signed withdrawal + `cancelRequestId`), `/orders/history` (GET, wallet implicit via JWT)
 - **Order types**: `single` (one directional trigger), `oco` (take-profit + stop-loss pair), `otoco` (entry trigger + OCO). `triggerCondition`: `"above"` or `"below"`.
 - **Architecture**: Off-chain custodial vault (Privy) per wallet. Orders invisible on-chain until execution — MEV-resistant. Triggers on USD price (not pool rate ratios). Partial fills supported.
-- **Gotchas**: Order creation is 3 steps — `GET /vault/register` (register if new), `POST /deposit/craft` (returns `transaction` + `requestId`), sign deposit tx, then `POST /orders/price` with `depositRequestId` + `depositSignedTx`. Cancellation is two-step — `POST /cancel/{orderId}` returns `transaction` + `requestId`; sign, then `POST /confirm-cancel/{orderId}` with `signedTransaction` + `cancelRequestId`. Response field is `id` (not `orderId`).
-- Refs: [Overview](https://developers.jup.ag/docs/trigger/index.md) | [Create order](https://developers.jup.ag/docs/trigger/create-order.md) | [Order history](https://developers.jup.ag/docs/trigger/order-history.md) | [Manage orders](https://developers.jup.ag/docs/trigger/manage-orders.md) | [OpenAPI](https://developers.jup.ag/docs/openapi-spec/trigger/v2/trigger.yaml)
+- **Gotchas**: Order creation is 3 steps — `GET /vault/register` (register if new; returns `409 "Vault already registered"` if it exists, which is fine), `POST /deposit/craft` (returns `transaction` + `requestId`; the body MUST include `orderType: "price"` and `orderSubType` (`single`/`oco`/`otoco`)), sign deposit tx, then `POST /orders/price` with `depositRequestId` + `depositSignedTx`. Cancellation is two-step — `POST /cancel/{orderId}` returns `transaction` + `requestId`; sign, then `POST /confirm-cancel/{orderId}` with `signedTransaction` + `cancelRequestId`. Create response field is `id` (not `orderId`); order history objects use `orderState`/`rawState` (no `status` field).
+- Refs: [Overview](https://developers.jup.ag/docs/trigger/index.md) | [Authentication](https://developers.jup.ag/docs/trigger/authentication.md) | [Create order](https://developers.jup.ag/docs/trigger/create-order.md) | [Order history](https://developers.jup.ag/docs/trigger/order-history.md) | [Manage orders](https://developers.jup.ag/docs/trigger/manage-orders.md) | [OpenAPI](https://developers.jup.ag/docs/openapi-spec/trigger/v2/trigger.yaml)
 
 ---
 
@@ -215,8 +219,8 @@ Common error codes returned by `/swap/v2/execute` with recommended actions:
 - **Base URL**: `https://api.jup.ag/tokens/v2`
 - **Triggers**: `token metadata`, `token search`, `shield`
 - **Endpoints**: `/search?query={q}` (GET, comma-separate mints, max 100), `/tag?query={tag}` (GET, `verified` or `lst`), `/{category}/{interval}` (GET, categories: `toporganicscore`, `toptraded`, `toptrending`; intervals: `5m`, `1h`, `6h`, `24h`), `/recent` (GET)
-- **Gotchas**: Use mint address as primary identity; treat symbol/name as convenience. Surface `audit.isSus` and `organicScore` in UX.
-- Refs: [Overview](https://developers.jup.ag/docs/tokens/index.md) | [Token info v2](https://developers.jup.ag/docs/tokens/v2/token-information.md) | [OpenAPI](https://developers.jup.ag/docs/openapi-spec/tokens/v2/tokens.yaml)
+- **Gotchas**: Use mint address as primary identity; treat symbol/name as convenience. Primary trust signal is top-level `isVerified` (boolean) plus `organicScore` (0-100) and `organicScoreLabel` (`high`/`medium`/`low`). Secondary risk flag: **`audit.isSus`** — a boolean present ONLY when `true` (a safe token has no `isSus` key at all), so check it defensively as `token.audit?.isSus === true`, never read it directly. Verified live on flagged tokens (dev holds ~100% of supply); those also carry `isVerified: null` and `organicScoreLabel: "low"`. Absence of `isSus` is NOT proof of safety — not all risky tokens carry the flag. Other conditional `audit` fields the live API returns: `mintAuthorityDisabled`, `freezeAuthorityDisabled`, `topHoldersPercentage`, `devBalancePercentage`, `devMigrations`, `devMints` (all nullable, any may be absent; `devMigrations` is returned but missing from the current OpenAPI schema).
+- Refs: [Overview](https://developers.jup.ag/docs/tokens/index.md) | [Token info v2](https://developers.jup.ag/docs/tokens/token-information.md) | [OpenAPI](https://developers.jup.ag/docs/openapi-spec/tokens/v2/tokens.yaml)
 
 ---
 
@@ -226,8 +230,9 @@ Common error codes returned by `/swap/v2/execute` with recommended actions:
 - **Triggers**: `price`, `valuation`, `price feed`
 - **Limit**: Max 50 mint IDs per request
 - **Endpoints**: `/price/v3?ids={mints}` (GET, comma-separated)
-- **Gotchas**: Tokens with unreliable pricing return `null` or are omitted (not an error). Fail closed on missing/low-confidence data for safety-sensitive actions. Use `confidenceLevel` field.
-- Refs: [Overview](https://developers.jup.ag/docs/price/index.md) | [Price v3](https://developers.jup.ag/docs/price/v3.md) | [OpenAPI](https://developers.jup.ag/docs/openapi-spec/price/v3/price.yaml)
+- **Response**: keyed by mint, each value has `usdPrice`, `blockId`, `decimals`, `priceChange24h`, `liquidity`, `createdAt` (some tokens add conditional fields like `launchpad`, `stockData`, `scaledUiConfig`). Price API V3 has NO `confidenceLevel` field (that was V2).
+- **Gotchas**: Tokens with unreliable pricing are omitted from the response entirely (not an error, no `null` placeholder). Fail closed when a requested mint is missing from the response for safety-sensitive actions. Use `blockId` to check price recency.
+- Refs: [Overview](https://developers.jup.ag/docs/price/index.md) | [OpenAPI](https://developers.jup.ag/docs/openapi-spec/price/v3/price.yaml)
 
 ---
 
@@ -250,8 +255,9 @@ Common error codes returned by `/swap/v2/execute` with recommended actions:
 - **Price convention**: 1,000,000 native units = $1.00 USD
 - **Triggers**: `prediction markets`, `market odds`, `event market`
 - **Deposit mints**: JupUSD (`JuprjznTrTSp2UFa3ZBUFgwdAmtZCq4MQCwysN55USD`), USDC
-- **Endpoints**: `/events` (GET), `/events/search` (GET), `/markets/{marketId}` (GET), `/orderbook/{marketId}` (GET), `/orders` (POST), `/orders/status/{pubkey}` (GET), `/positions` (GET), `/positions/{pubkey}` (DELETE), `/positions/{pubkey}/claim` (POST), `/history` (GET), `/leaderboards` (GET)
-- **Gotchas**: Check `position.claimable` before claiming. Winners get $1/contract.
+- **Min order**: $5 (5,000,000 native units)
+- **Endpoints**: `/events` (GET, returns `{data, pagination}`), `/events/search` (GET), `/markets/{marketId}` (GET), `/orderbook/{marketId}` (GET, returns `{yes, no, yes_dollars, no_dollars}`), `/orders` (POST, requires `isBuy` boolean + `ownerPubkey`), `/orders/status/{orderPubkey}` (GET), `/positions` (GET, `?ownerPubkey=`), `/positions/{positionPubkey}` (DELETE), `/positions/{positionPubkey}/claim` (POST), `/history` (GET), `/leaderboards` (GET)
+- **Gotchas**: Check `position.claimable` before claiming. Winners get $1/contract. Markets are FLAT (fields like `provider`, `marketId`, `result`, `resolveAt`, `outcomes`, `clobTokenIds` live at the top level, not nested under `metadata`). Contracts are fractional: use `contractsMicro` (1,000,000 = 1 contract) or `contractsDecimal`, not the legacy whole-number `contracts`.
 - Refs: [Overview](https://developers.jup.ag/docs/prediction/index.md) | [Events](https://developers.jup.ag/docs/prediction/events-and-markets.md) | [Positions](https://developers.jup.ag/docs/prediction/open-positions.md) | [OpenAPI](https://developers.jup.ag/docs/openapi-spec/prediction/prediction.yaml)
 
 ---
@@ -296,11 +302,11 @@ Common error codes returned by `/swap/v2/execute` with recommended actions:
 ### Routing
 
 - **Triggers**: `dex integration`, `rfq integration`, `routing engine`
-- **Engines**: Juno (meta-aggregator), Iris (multi-hop DEX routing, powers Swap API), JupiterZ (RFQ market maker quotes)
-- **DEX Integration** (into Iris): Free, no fees. Prereqs: code health, security audit, market traction. Implement `jupiter-amm-interface` crate. **Critical**: No network calls in implementation (accounts are pre-batched and cached). Ref impl: [github.com/jup-ag/rust-amm-implementation](https://github.com/jup-ag/rust-amm-implementation)
+- **Engines**: Juno (meta-aggregator), Metis (multi-hop DEX routing, powers the Swap API; formerly called Iris), JupiterZ (RFQ market maker quotes)
+- **DEX Integration** (into Metis): Free, no fees. Prereqs: code health, security audit, market traction. Implement `jupiter-amm-interface` crate. **Critical**: No network calls in implementation (accounts are pre-batched and cached). Ref impl: [github.com/jup-ag/rust-amm-implementation](https://github.com/jup-ag/rust-amm-implementation)
 - **RFQ Integration** (JupiterZ): Market makers host webhook at `/jupiter/rfq/quote` (POST, 250ms), `/jupiter/rfq/swap` (POST), `/jupiter/rfq/tokens` (GET). Reqs: 95% fill rate, 250ms response, 55s expiry. SDK: [github.com/jup-ag/rfq-webhook-toolkit](https://github.com/jup-ag/rfq-webhook-toolkit)
 - **Market Listing**: Instant routing for tokens < 30 days old. Normal routing (checked every 30 min) requires < 30% loss on $500 round-trip OR < 20% price impact comparing $1k vs $500.
-- Refs: [Overview](https://developers.jup.ag/docs/routing/index.md) | [DEX integration](https://developers.jup.ag/docs/routing/dex-integration.md) | [RFQ integration](https://developers.jup.ag/docs/routing/rfq-integration.md) | [Market listing](https://developers.jup.ag/docs/routing/market-listing.md)
+- Refs: [DEX integration](https://developers.jup.ag/docs/swap/routing/dex-integration.md) | [RFQ integration](https://developers.jup.ag/docs/swap/routing/rfq-integration.md) | [Market listing](https://developers.jup.ag/docs/swap/routing/market-listing.md)
 
 ---
 
@@ -317,7 +323,7 @@ Common error codes returned by `/swap/v2/execute` with recommended actions:
 
 Quotas recalculate every 10 minutes. Pro plan does NOT increase Swap API limits.
 
-**Other APIs**: Managed at portal level. Check [portal rate limits](https://developers.jup.ag/docs/portal/rate-limit.md).
+**Other APIs**: Managed at portal level. Check [portal rate limits](https://developers.jup.ag/docs/portal/rate-limits.md).
 
 **On HTTP 429**: Exponential backoff with jitter: `delay = min(baseDelay * 2^attempt + random(0, jitter), maxDelay)`. Wait for 10s sliding window refresh. Do NOT burst aggressively.
 
@@ -338,7 +344,7 @@ Quotas recalculate every 10 minutes. Pro plan does NOT increase Swap API limits.
 
 1. Start from the API-specific overview before coding endpoint calls.
 2. Enforce auth as a hard precondition for every request. Ref: [Portal setup](https://developers.jup.ag/docs/portal/setup.md)
-3. Design retry logic around documented rate-limit behavior, not fixed assumptions. Ref: [Rate limits](https://developers.jup.ag/docs/portal/rate-limit.md)
+3. Design retry logic around documented rate-limit behavior, not fixed assumptions. Ref: [Rate limits](https://developers.jup.ag/docs/portal/rate-limits.md)
 4. Map all non-success responses to typed app errors using documented response semantics. Ref: [API responses](https://developers.jup.ag/docs/portal/responses.md)
 5. For order-based products (Swap/Trigger/Recurring), separate create/execute/retrieve phases in code and logs.
 6. Treat network/service health as part of runtime behavior (degrade gracefully). Ref: [Status page](https://status.jup.ag/)
@@ -416,10 +422,10 @@ Always fetch the freshest context from referenced docs/specs before executing a 
 ## Operational References
 
 - [Portal setup](https://developers.jup.ag/docs/portal/setup.md) — API key configuration
-- [Rate limits](https://developers.jup.ag/docs/portal/rate-limit.md) — Global rate limit policy
-- [Swap routing](https://developers.jup.ag/docs/swap/v2/routing.md) — Router competition and parameter impact
+- [Rate limits](https://developers.jup.ag/docs/portal/rate-limits.md) — Global rate limit policy
+- [Swap overview](https://developers.jup.ag/docs/swap/index.md) — Router competition and parameter impact
 - [API responses](https://developers.jup.ag/docs/portal/responses.md) — Response format standards
-- [Swap order & execute](https://developers.jup.ag/docs/swap/v2/order-and-execute.md) — Detailed error codes and response format
+- [Swap order & execute](https://developers.jup.ag/docs/swap/order-and-execute.md) — Detailed error codes and response format
 - [Status page](https://status.jup.ag/) — Service health
 - [Documentation sitemap](https://developers.jup.ag/docs/llms.txt) — Full docs index
 - [Tool Kits](https://developers.jup.ag/docs/tool-kits/plugin/index.md) — Plugin, Wallet Kit, Referral Program

--- a/.plugins/integrate-jupiter/claude/skills/integrating-jupiter/SKILL.md
+++ b/.plugins/integrate-jupiter/claude/skills/integrating-jupiter/SKILL.md
@@ -4,7 +4,7 @@ description: Comprehensive guidance for integrating Jupiter APIs (Swap, Lend, Pe
 license: MIT
 metadata:
   author: jup-ag
-  version: "1.1.0"
+  version: "1.1.1"
 tags:
   - jupiter
   - jup-ag
@@ -131,9 +131,13 @@ Use each block as a minimal execution contract. Fetch the linked refs for full r
 - **Fee**: Variable by pair — 0 bps (Jupiter tokens/pegged), 2 bps (SOL-Stable), 5 bps (LST-Stable), 10 bps (most pairs), 50 bps (tokens < 24h). Referral fees: 50-255 bps (Jupiter retains 20%).
 - **Rate Limit**: 50 req/10s base, scales with 24h execute volume (see [Rate Limits](#rate-limits))
 - **Endpoints**: `/order` (GET), `/execute` (POST), `/build` (GET, Metis-only raw instructions)
-- **Routing**: 4 routers compete — Metis (`metis`), JupiterZ (`jupiterz`), Dflow (`dflow`), OKX (`okx`). The `router` response field returns one of these values (`metis`, not the legacy `iris`). `swapType` is `aggregator` (Metis, Dflow, or OKX) or `rfq` (JupiterZ). Response `mode` field: `"ultra"` (all routers, default params) or `"manual"` (restricted by optional params). `/build` uses Metis only.
+- **Routing**: 4 routers compete — Metis (`metis`), JupiterZ (`jupiterz`), Dflow (`dflow`), OKX (`okx`). The `router` response field returns one of these values. `swapType` is `aggregator` (Metis, Dflow, or OKX) or `rfq` (JupiterZ). Response `mode` field: `"ultra"` (all routers, default params) or `"manual"` (restricted by optional params). `/build` uses Metis only.
 - **Gasless**: Three paths — automatic (Jupiter-covered), JupiterZ (MM-covered), integrator-payer (`payer` param, Metis-only routing). Eligibility varies by balance, trade size, and parameters used. See [Gasless docs](https://developers.jup.ag/docs/swap/advanced/gasless.md) for current thresholds and disqualifying params.
-- **Gotchas**: Signed payloads have ~2 min TTL. Transactions are immutable after receipt. Split order/execute in code and logging. Re-quote before execution when conditions may have changed. Routing impact of optional params: `referralAccount` + `referralFee` disable JupiterZ only (Metis/Dflow/OKX remain); `payer` (integrator gasless) restricts routing to Metis only (disables JupiterZ, Dflow, and OKX); `receiver` does NOT restrict routing, but must differ from `taker` (`receiver=taker` returns `400 "Receiver cannot be same as taker"`). `/build` transactions cannot use `/execute` — self-manage via RPC.
+- **Gotchas**:
+  - Signed payloads have ~2 min TTL. Transactions are immutable after receipt.
+  - Split order/execute in code and logging. Re-quote before execution when conditions may have changed.
+  - Routing impact of optional params: `referralAccount` + `referralFee` disable JupiterZ only (Metis/Dflow/OKX remain); `payer` (integrator gasless) restricts routing to Metis only (disables JupiterZ, Dflow, and OKX); `receiver` does NOT restrict routing, but must differ from `taker` (`receiver=taker` returns `400 "Receiver cannot be same as taker"`).
+  - `/build` transactions cannot use `/execute` — self-manage via RPC.
 - **Migrating from an older integration?** Use the `jupiter-swap-migration` skill.
 - Refs: [Overview](https://developers.jup.ag/docs/swap/index.md) | [Order & Execute](https://developers.jup.ag/docs/swap/order-and-execute.md) | [Build](https://developers.jup.ag/docs/swap/build/index.md) | [Gasless](https://developers.jup.ag/docs/swap/advanced/gasless.md) | [Migration](https://developers.jup.ag/docs/swap/migration/ultra-to-order.md) | [OpenAPI](https://developers.jup.ag/docs/openapi-spec/swap/v2/swap.yaml)
 
@@ -196,7 +200,10 @@ On success, `/execute` returns `{ status: "Success", code: 0, signature, inputAm
 - **Endpoints**: `/auth/challenge` (POST, body: `walletPubkey` + `type`), `/auth/verify` (POST, body: `type` + `walletPubkey` + base58 `signature`), `/vault` (GET), `/vault/register` (GET), `/deposit/craft` (POST), `/orders/price` (POST create, PATCH update), `/orders/price/cancel/{orderId}` (POST, initiates withdrawal), `/orders/price/confirm-cancel/{orderId}` (POST, submits signed withdrawal + `cancelRequestId`), `/orders/history` (GET, wallet implicit via JWT)
 - **Order types**: `single` (one directional trigger), `oco` (take-profit + stop-loss pair), `otoco` (entry trigger + OCO). `triggerCondition`: `"above"` or `"below"`.
 - **Architecture**: Off-chain custodial vault (Privy) per wallet. Orders invisible on-chain until execution — MEV-resistant. Triggers on USD price (not pool rate ratios). Partial fills supported.
-- **Gotchas**: Order creation is 3 steps — `GET /vault/register` (register if new; returns `409 "Vault already registered"` if it exists, which is fine), `POST /deposit/craft` (returns `transaction` + `requestId`; the body MUST include `orderType: "price"` and `orderSubType` (`single`/`oco`/`otoco`)), sign deposit tx, then `POST /orders/price` with `depositRequestId` + `depositSignedTx`. Cancellation is two-step — `POST /cancel/{orderId}` returns `transaction` + `requestId`; sign, then `POST /confirm-cancel/{orderId}` with `signedTransaction` + `cancelRequestId`. Create response field is `id` (not `orderId`); order history objects use `orderState`/`rawState` (no `status` field).
+- **Gotchas**:
+  - Order creation is 3 steps — `GET /vault/register` (register if new; returns `409 "Vault already registered"` if it exists, which is fine), `POST /deposit/craft` (returns `transaction` + `requestId`; the body MUST include `orderType: "price"` and `orderSubType` (`single`/`oco`/`otoco`)), sign deposit tx, then `POST /orders/price` with `depositRequestId` + `depositSignedTx`.
+  - Cancellation is two-step — `POST /cancel/{orderId}` returns `transaction` + `requestId`; sign, then `POST /confirm-cancel/{orderId}` with `signedTransaction` + `cancelRequestId`.
+  - Create response field is `id` (not `orderId`); order history objects use `orderState`/`rawState` (no `status` field).
 - Refs: [Overview](https://developers.jup.ag/docs/trigger/index.md) | [Authentication](https://developers.jup.ag/docs/trigger/authentication.md) | [Create order](https://developers.jup.ag/docs/trigger/create-order.md) | [Order history](https://developers.jup.ag/docs/trigger/order-history.md) | [Manage orders](https://developers.jup.ag/docs/trigger/manage-orders.md) | [OpenAPI](https://developers.jup.ag/docs/openapi-spec/trigger/v2/trigger.yaml)
 
 ---
@@ -219,7 +226,11 @@ On success, `/execute` returns `{ status: "Success", code: 0, signature, inputAm
 - **Base URL**: `https://api.jup.ag/tokens/v2`
 - **Triggers**: `token metadata`, `token search`, `shield`
 - **Endpoints**: `/search?query={q}` (GET, comma-separate mints, max 100), `/tag?query={tag}` (GET, `verified` or `lst`), `/{category}/{interval}` (GET, categories: `toporganicscore`, `toptraded`, `toptrending`; intervals: `5m`, `1h`, `6h`, `24h`), `/recent` (GET)
-- **Gotchas**: Use mint address as primary identity; treat symbol/name as convenience. Primary trust signal is top-level `isVerified` (boolean) plus `organicScore` (0-100) and `organicScoreLabel` (`high`/`medium`/`low`). Secondary risk flag: **`audit.isSus`** — a boolean present ONLY when `true` (a safe token has no `isSus` key at all), so check it defensively as `token.audit?.isSus === true`, never read it directly. Verified live on flagged tokens (dev holds ~100% of supply); those also carry `isVerified: null` and `organicScoreLabel: "low"`. Absence of `isSus` is NOT proof of safety — not all risky tokens carry the flag. Other conditional `audit` fields the live API returns: `mintAuthorityDisabled`, `freezeAuthorityDisabled`, `topHoldersPercentage`, `devBalancePercentage`, `devMigrations`, `devMints` (all nullable, any may be absent; `devMigrations` is returned but missing from the current OpenAPI schema).
+- **Gotchas**:
+  - Use mint address as primary identity; treat symbol/name as convenience.
+  - Primary trust signal is top-level `isVerified` (boolean) plus `organicScore` (0-100) and `organicScoreLabel` (`high`/`medium`/`low`).
+  - Secondary risk flag: **`audit.isSus`** — a boolean present ONLY when `true` (a safe token has no `isSus` key at all), so check it defensively as `token.audit?.isSus === true`, never read it directly. Verified live on flagged tokens (dev holds ~100% of supply); those also carry `isVerified: null` and `organicScoreLabel: "low"`. Absence of `isSus` is NOT proof of safety — not all risky tokens carry the flag.
+  - Other conditional `audit` fields the live API returns: `mintAuthorityDisabled`, `freezeAuthorityDisabled`, `topHoldersPercentage`, `devBalancePercentage`, `devMigrations`, `devMints` (all nullable, any may be absent; `devMigrations` is returned but missing from the current OpenAPI schema).
 - Refs: [Overview](https://developers.jup.ag/docs/tokens/index.md) | [Token info v2](https://developers.jup.ag/docs/tokens/token-information.md) | [OpenAPI](https://developers.jup.ag/docs/openapi-spec/tokens/v2/tokens.yaml)
 
 ---
@@ -257,7 +268,10 @@ On success, `/execute` returns `{ status: "Success", code: 0, signature, inputAm
 - **Deposit mints**: JupUSD (`JuprjznTrTSp2UFa3ZBUFgwdAmtZCq4MQCwysN55USD`), USDC
 - **Min order**: $5 (5,000,000 native units)
 - **Endpoints**: `/events` (GET, returns `{data, pagination}`), `/events/search` (GET), `/markets/{marketId}` (GET), `/orderbook/{marketId}` (GET, returns `{yes, no, yes_dollars, no_dollars}`), `/orders` (POST, requires `isBuy` boolean + `ownerPubkey`), `/orders/status/{orderPubkey}` (GET), `/positions` (GET, `?ownerPubkey=`), `/positions/{positionPubkey}` (DELETE), `/positions/{positionPubkey}/claim` (POST), `/history` (GET), `/leaderboards` (GET)
-- **Gotchas**: Check `position.claimable` before claiming. Winners get $1/contract. Markets are FLAT (fields like `provider`, `marketId`, `result`, `resolveAt`, `outcomes`, `clobTokenIds` live at the top level, not nested under `metadata`). Contracts are fractional: use `contractsMicro` (1,000,000 = 1 contract) or `contractsDecimal`, not the legacy whole-number `contracts`.
+- **Gotchas**:
+  - Check `position.claimable` before claiming. Winners get $1/contract.
+  - Markets are FLAT — fields like `provider`, `marketId`, `result`, `resolveAt`, `outcomes`, `clobTokenIds` live at the top level, not nested under `metadata`.
+  - Contracts are fractional: use `contractsMicro` (1,000,000 = 1 contract) or `contractsDecimal`, not the legacy whole-number `contracts`.
 - Refs: [Overview](https://developers.jup.ag/docs/prediction/index.md) | [Events](https://developers.jup.ag/docs/prediction/events-and-markets.md) | [Positions](https://developers.jup.ag/docs/prediction/open-positions.md) | [OpenAPI](https://developers.jup.ag/docs/openapi-spec/prediction/prediction.yaml)
 
 ---

--- a/.plugins/integrate-jupiter/claude/skills/integrating-jupiter/examples/price.md
+++ b/.plugins/integrate-jupiter/claude/skills/integrating-jupiter/examples/price.md
@@ -14,35 +14,35 @@ const SOL_MINT = 'So11111111111111111111111111111111111111112';
 const USDC_MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
 const WBTC_MINT = '3NZ9JMVBmGAqocybic2c7LQCJScmgsAZ6vQqTDzcqmJh';
 
-async function getPrices(mints: string[], confidenceLevel: 'low' | 'medium' | 'high' = 'medium') {
-  const ids = mints.join(',');
+// Price API V3 response is keyed by mint. Each entry has usdPrice (number),
+// blockId, decimals, priceChange24h, and liquidity. There is NO confidenceLevel
+// field (that was V2). Mints with no reliable price are OMITTED from the
+// response entirely — there is no null placeholder — so treat a missing mint
+// as "unpriced" and fail closed for safety-sensitive actions.
+type PriceEntry = {
+  usdPrice: number;
+  blockId: number;
+  decimals: number;
+  priceChange24h: number;
+  liquidity?: number;
+};
 
-  const data = await jupiterFetch<{
-    data: Record<string, { price: string; confidenceLevel?: string } | null>;
-  }>(`/price/v3?ids=${encodeURIComponent(ids)}`);
+async function getPrices(mints: string[]) {
+  const ids = mints.join(','); // max 50 mints per request
 
-  const prices: Record<string, { price: number; confidence: string } | null> = {};
+  const data = await jupiterFetch<Record<string, PriceEntry>>(
+    `/price/v3?ids=${encodeURIComponent(ids)}`,
+  );
 
+  const prices: Record<string, PriceEntry | null> = {};
   for (const mint of mints) {
-    const entry = data.data?.[mint];
-    if (!entry || !entry.price) {
-      prices[mint] = null; // token not priced or unreliable
-      continue;
-    }
-
-    // Filter by confidence — fail closed on low-confidence data
-    const levels = ['low', 'medium', 'high'];
-    const entryLevel = entry.confidenceLevel || 'low';
-    if (levels.indexOf(entryLevel) < levels.indexOf(confidenceLevel)) {
-      prices[mint] = null;
-      continue;
-    }
-
-    prices[mint] = { price: parseFloat(entry.price), confidence: entryLevel };
+    // Missing mint => no reliable price. Fail closed.
+    prices[mint] = data[mint] ?? null;
   }
-
   return prices;
 }
 
-// Usage: getPrices([SOL_MINT, USDC_MINT, WBTC_MINT])
+// Usage:
+// const prices = await getPrices([SOL_MINT, USDC_MINT, WBTC_MINT]);
+// const solUsd = prices[SOL_MINT]?.usdPrice; // number | undefined
 ```

--- a/.plugins/integrate-jupiter/claude/skills/integrating-jupiter/examples/trigger.md
+++ b/.plugins/integrate-jupiter/claude/skills/integrating-jupiter/examples/trigger.md
@@ -93,6 +93,8 @@ async function craftDeposit(jwt: string, inputMint: string, amount: string) {
       outputMint: USDC_MINT,    // destination token for the order
       userAddress: wallet.publicKey.toBase58(),
       amount,
+      orderType: 'price',       // required
+      orderSubType: 'single',   // required: match the order you will create (single | oco | otoco)
     }),
   });
 

--- a/.plugins/integrate-jupiter/claude/skills/jupiter-lend/SKILL.md
+++ b/.plugins/integrate-jupiter/claude/skills/jupiter-lend/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: jupiter-lend
-version: 0.1.2
+version: 0.1.3
 description: Interact with Jupiter Lend Protocol. Read-only SDK (@jup-ag/lend-read) for querying liquidity pools, lending markets (jlTokens), and vaults. Write SDK (@jup-ag/lend) for lending (deposit/withdraw) and vault operations (deposit collateral, borrow, repay, manage positions).
 homepage: https://jup.ag/lend
 metadata:
@@ -359,9 +359,9 @@ The Jupiter Lend Build Kit offers developer components, powerful utilities, and 
 - **Wallet integrations (Privy)**: [Earn with Privy](https://developers.jup.ag/docs/lend/wallets/privy-earn), [Borrow with Privy](https://developers.jup.ag/docs/lend/wallets/privy-borrow)
 - **Borrow**: [overview](https://developers.jup.ag/docs/lend/borrow), [create position](https://developers.jup.ag/docs/lend/borrow/create-position), [deposit](https://developers.jup.ag/docs/lend/borrow/deposit), [borrow](https://developers.jup.ag/docs/lend/borrow/borrow), [repay](https://developers.jup.ag/docs/lend/borrow/repay), [withdraw](https://developers.jup.ag/docs/lend/borrow/withdraw), [combined operate](https://developers.jup.ag/docs/lend/borrow/combined), [liquidate](https://developers.jup.ag/docs/lend/borrow/liquidation), [read vault data](https://developers.jup.ag/docs/lend/borrow/read-vault-data)
 - **Flashloan**: [overview](https://developers.jup.ag/docs/lend/flashloan), [execute](https://developers.jup.ag/docs/lend/flashloan/execute)
-- **Advanced**: [advanced/multiply](https://developers.jup.ag/docs/lend/advanced/multiply), [advanced/unwind](https://developers.jup.ag/docs/lend/advanced/unwind), [advanced/repay-withdraw-collateral](https://developers.jup.ag/docs/lend/advanced/repay-with-collateral-max-withdraw), [advanced/vault-swap](https://developers.jup.ag/docs/lend/advanced/vault-swap), [advanced/utilization-after-deposit](https://developers.jup.ag/docs/lend/advanced/utilization-after-deposit), [advanced/native-staked-vault/overview](https://developers.jup.ag/docs/lend/advanced/native-staked-vault/overview), [advanced/native-staked-vault/deposit](https://developers.jup.ag/docs/lend/advanced/native-staked-vault/deposit), [advanced/native-staked-vault/withdraw](https://developers.jup.ag/docs/lend/advanced/native-staked-vault/withdraw)
+- **Advanced**: [advanced/multiply](https://developers.jup.ag/docs/lend/advanced/multiply), [advanced/unwind](https://developers.jup.ag/docs/lend/advanced/unwind), [advanced/repay-withdraw-collateral](https://developers.jup.ag/docs/lend/advanced/repay-with-collateral-max-withdraw), [advanced/vault-swap](https://developers.jup.ag/docs/lend/advanced/vault-swap), [advanced/utilization-after-deposit](https://developers.jup.ag/docs/lend/advanced/utilization-after-deposit), [advanced/native-staked-vault/overview](https://developers.jup.ag/docs/lend/advanced/native-staked-vault), [advanced/native-staked-vault/deposit](https://developers.jup.ag/docs/lend/advanced/native-staked-vault/deposit), [advanced/native-staked-vault/withdraw](https://developers.jup.ag/docs/lend/advanced/native-staked-vault/withdraw)
 - **Liquidity**: [liquidity/analytics](https://developers.jup.ag/docs/lend/liquidity/analytics)
-- **Resources**: [resources/program-addresses](https://developers.jup.ag/docs/lend/resources/program-addresses), [resources/idl-and-types](https://developers.jup.ag/docs/lend/resources/idl-and-types), [resources/dune](https://developers.jup.ag/docs/lend/resources/dune)
+- **Resources**: [resources/program-addresses](https://developers.jup.ag/docs/lend/program-addresses), [resources/idl-and-types](https://developers.jup.ag/docs/lend/idl-and-types), [resources/dune](https://developers.jup.ag/docs/lend/dune)
 
 ---
 

--- a/.plugins/integrate-jupiter/claude/skills/jupiter-swap-migration/SKILL.md
+++ b/.plugins/integrate-jupiter/claude/skills/jupiter-swap-migration/SKILL.md
@@ -4,7 +4,7 @@ description: Migration guide from Jupiter Metis (v1) or Ultra to Swap API v2. Us
 license: MIT
 metadata:
   author: jup-ag
-  version: "1.0.1"
+  version: "1.1.0"
 tags:
   - jupiter
   - swap-migration
@@ -64,7 +64,7 @@ Each path has a dedicated example with before/after code, parameter mappings, an
 6. **ALT handling**: If using `/build`, switch from `addressLookupTableAddresses` (array) to `addressesByLookupTableAddress` (object) — remove RPC ALT resolution code
 7. **Fee event parsing**: V2 instructions don't emit fee events — update any transaction parser that depends on them
 8. **Route plan format**: If parsing route plans, use `bps` field (canonical) instead of `percent`
-9. **Error codes**: Update error handling to match [Swap v2 error codes](https://developers.jup.ag/docs/swap/v2/order-and-execute.md)
+9. **Error codes**: Update error handling to match [Swap v2 error codes](https://developers.jup.ag/docs/swap/order-and-execute.md)
 10. **Test**: Run end-to-end swap on devnet/mainnet with small amount to verify
 
 ## Sunset
@@ -75,9 +75,12 @@ Remove this skill once Jupiter decommissions the v1 (`/swap/v1`) endpoints and t
 
 ## References
 
-- [Migration guide](https://developers.jup.ag/docs/swap/v2/migration.md)
-- [Order & Execute](https://developers.jup.ag/docs/swap/v2/order-and-execute.md)
-- [Build](https://developers.jup.ag/docs/swap/v2/build/index.md)
-- [Fees](https://developers.jup.ag/docs/swap/v2/fees.md)
-- [Routing](https://developers.jup.ag/docs/swap/v2/routing.md)
+Migration is split into three profile-targeted guides (the old single `migration` page no longer exists):
+
+- [Migration: Ultra → /order](https://developers.jup.ag/docs/swap/migration/ultra-to-order.md)
+- [Migration: Metis → /build](https://developers.jup.ag/docs/swap/migration/metis-to-build.md)
+- [Migration: Metis → Meta-Aggregator (/order + /execute)](https://developers.jup.ag/docs/swap/migration/metis-to-meta-aggregator.md)
+- [Order & Execute](https://developers.jup.ag/docs/swap/order-and-execute.md)
+- [Build](https://developers.jup.ag/docs/swap/build/index.md)
+- [Swap overview](https://developers.jup.ag/docs/swap/index.md) (routing and fees)
 - [OpenAPI spec](https://developers.jup.ag/docs/openapi-spec/swap/v2/swap.yaml)

--- a/.plugins/integrate-jupiter/claude/skills/jupiter-swap-migration/examples/ultra-to-order.md
+++ b/.plugins/integrate-jupiter/claude/skills/jupiter-swap-migration/examples/ultra-to-order.md
@@ -53,7 +53,7 @@ const result = await fetch(`${BASE_URL}/execute`, {
 ## New response fields
 
 The v2 `/order` response now also includes:
-- `router` — which router won: `"iris"`, `"jupiterz"`, `"dflow"`, or `"okx"`
+- `router` — which router won: `"metis"`, `"jupiterz"`, `"dflow"`, or `"okx"`
 - `mode` — `"ultra"` (all routers competed) or `"manual"` (optional params restricted routing)
 - `feeBps` — fee basis points applied
 - `feeMint` — mint of the fee token

--- a/.plugins/integrate-jupiter/codex/.codex-plugin/plugin.json
+++ b/.plugins/integrate-jupiter/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "integrate-jupiter",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Jupiter integration and documentation skills for Solana, crypto, and finance workflows",
   "author": {
     "name": "Jupiter",

--- a/.plugins/integrate-jupiter/codex/.codex-plugin/plugin.json
+++ b/.plugins/integrate-jupiter/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "integrate-jupiter",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Jupiter integration and documentation skills for Solana, crypto, and finance workflows",
   "author": {
     "name": "Jupiter",

--- a/.plugins/integrate-jupiter/codex/skills/integrating-jupiter/README.md
+++ b/.plugins/integrate-jupiter/codex/skills/integrating-jupiter/README.md
@@ -20,7 +20,7 @@ Skills for AI coding agents in the Jupiter ecosystem.
 | Send | Token transfers via invite links |
 | Studio | Token creation with Dynamic Bonding Curves |
 | Lock | Token vesting and lock (on-chain program) |
-| Routing | DEX aggregation (Iris), RFQ (JupiterZ), and market listing |
+| Routing | DEX aggregation (Metis), RFQ (JupiterZ), and market listing |
 
 ## Examples
 
@@ -28,7 +28,7 @@ Production-ready code snippets in `examples/`:
 - `swap.md` — Swap order → sign → execute → confirm
 - `lend.md` — USDC deposit into Jupiter Lend
 - `trigger.md` — Create and execute a limit order
-- `price.md` — Multi-token price lookup with confidence filtering
+- `price.md` — Multi-token price lookup with fail-closed handling for unpriced mints
 
 ## Related skills
 

--- a/.plugins/integrate-jupiter/codex/skills/integrating-jupiter/SKILL.md
+++ b/.plugins/integrate-jupiter/codex/skills/integrating-jupiter/SKILL.md
@@ -4,7 +4,7 @@ description: Comprehensive guidance for integrating Jupiter APIs (Swap, Lend, Pe
 license: MIT
 metadata:
   author: jup-ag
-  version: "1.0.1"
+  version: "1.1.0"
 tags:
   - jupiter
   - jup-ag
@@ -27,7 +27,7 @@ tags:
   - jupiter-lock
   - jupiter-routing
   - jupiterz-rfq
-  - iris
+  - metis
   - jupiter-price-api
   - jupiter-tokens-api
   - jupiter-portal
@@ -131,11 +131,13 @@ Use each block as a minimal execution contract. Fetch the linked refs for full r
 - **Fee**: Variable by pair — 0 bps (Jupiter tokens/pegged), 2 bps (SOL-Stable), 5 bps (LST-Stable), 10 bps (most pairs), 50 bps (tokens < 24h). Referral fees: 50-255 bps (Jupiter retains 20%).
 - **Rate Limit**: 50 req/10s base, scales with 24h execute volume (see [Rate Limits](#rate-limits))
 - **Endpoints**: `/order` (GET), `/execute` (POST), `/build` (GET, Metis-only raw instructions)
-- **Routing**: 4 routers compete — Metis (API value: `iris`), JupiterZ (`jupiterz`), Dflow (`dflow`), OKX (`okx`). Response `mode` field: `"ultra"` (all routers, default params) or `"manual"` (restricted by optional params). `/build` uses Metis only.
-- **Gasless**: Three paths — automatic (Jupiter-covered), JupiterZ (MM-covered), integrator-payer (`payer` param, Metis-only routing). Eligibility varies by balance, trade size, and parameters used. See [Gasless docs](https://developers.jup.ag/docs/swap/v2/advanced/gasless.md) for current thresholds and disqualifying params.
-- **Gotchas**: Signed payloads have ~2 min TTL. Transactions are immutable after receipt. Split order/execute in code and logging. Re-quote before execution when conditions may have changed. `referralAccount`/`referralFee`/`receiver` disable JupiterZ only (Metis/Dflow/OKX remain). `payer` reduces routing to Metis only (per gasless docs; routing docs group all four as disabling JupiterZ but do not itemize the additional Dflow/OKX restriction). `/build` transactions cannot use `/execute` — self-manage via RPC.
+- **Routing**: 4 routers compete — Metis (`metis`), JupiterZ (`jupiterz`), Dflow (`dflow`), OKX (`okx`). The `router` response field returns one of these values (`metis`, not the legacy `iris`). `swapType` is `aggregator` (Metis, Dflow, or OKX) or `rfq` (JupiterZ). Response `mode` field: `"ultra"` (all routers, default params) or `"manual"` (restricted by optional params). `/build` uses Metis only.
+- **Gasless**: Three paths — automatic (Jupiter-covered), JupiterZ (MM-covered), integrator-payer (`payer` param, Metis-only routing). Eligibility varies by balance, trade size, and parameters used. See [Gasless docs](https://developers.jup.ag/docs/swap/advanced/gasless.md) for current thresholds and disqualifying params.
+- **Gotchas**: Signed payloads have ~2 min TTL. Transactions are immutable after receipt. Split order/execute in code and logging. Re-quote before execution when conditions may have changed. Routing impact of optional params: `referralAccount` + `referralFee` disable JupiterZ only (Metis/Dflow/OKX remain); `payer` (integrator gasless) restricts routing to Metis only (disables JupiterZ, Dflow, and OKX); `receiver` does NOT restrict routing, but must differ from `taker` (`receiver=taker` returns `400 "Receiver cannot be same as taker"`). `/build` transactions cannot use `/execute` — self-manage via RPC.
 - **Migrating from an older integration?** Use the `jupiter-swap-migration` skill.
-- Refs: [Overview](https://developers.jup.ag/docs/swap/index.md) | [Order & Execute](https://developers.jup.ag/docs/swap/v2/order-and-execute.md) | [Build](https://developers.jup.ag/docs/swap/v2/build/index.md) | [Fees](https://developers.jup.ag/docs/swap/v2/fees.md) | [Routing](https://developers.jup.ag/docs/swap/v2/routing.md) | [Gasless](https://developers.jup.ag/docs/swap/v2/advanced/gasless.md) | [Migration](https://developers.jup.ag/docs/swap/v2/migration.md) | [OpenAPI](https://developers.jup.ag/docs/openapi-spec/swap/v2/swap.yaml)
+- Refs: [Overview](https://developers.jup.ag/docs/swap/index.md) | [Order & Execute](https://developers.jup.ag/docs/swap/order-and-execute.md) | [Build](https://developers.jup.ag/docs/swap/build/index.md) | [Gasless](https://developers.jup.ag/docs/swap/advanced/gasless.md) | [Migration](https://developers.jup.ag/docs/swap/migration/ultra-to-order.md) | [OpenAPI](https://developers.jup.ag/docs/openapi-spec/swap/v2/swap.yaml)
+
+  Fees are documented inline on the Order & Execute and Build pages; router competition and the parameter routing-impact matrix are on the Overview and Order & Execute pages.
 
 Common error codes returned by `/swap/v2/execute` with recommended actions:
 
@@ -157,6 +159,8 @@ Common error codes returned by `/swap/v2/execute` with recommended actions:
 | `-2004` | RFQ | Swap rejected | Yes | Re-quote, possibly different route |
 | `429` | Rate limit | Rate limited | Yes | Exponential backoff, wait 10s window |
 
+On success, `/execute` returns `{ status: "Success", code: 0, signature, inputAmountResult, outputAmountResult, slot, totalInputAmount, totalOutputAmount }`. On failure it returns `status: "Failed"` with a non-zero `code` and an `error` string. `inputAmountResult`/`outputAmountResult` are the actual on-chain amounts; reconcile against your quote.
+
 
 ---
 
@@ -169,7 +173,7 @@ Common error codes returned by `/swap/v2/execute` with recommended actions:
 - **Endpoints**: `/earn/deposit` (POST), `/earn/withdraw` (POST), `/earn/mint` (POST), `/earn/redeem` (POST), `/earn/deposit-instructions` (POST), `/earn/withdraw-instructions` (POST), `/earn/tokens` (GET), `/earn/positions` (GET), `/earn/earnings` (GET)
 - **Gotchas**: Recompute account state before each state-changing action. Encode risk checks (health factors, liquidation boundaries) as preconditions. All deposit/withdraw/mint/redeem return base64 unsigned `VersionedTransaction`.
 - **For SDK-level integration** with `@jup-ag/lend` and `@jup-ag/lend-read`, use the `jupiter-lend` skill.
-- Refs: [Overview](https://developers.jup.ag/docs/lend/index.md) | [Earn](https://developers.jup.ag/docs/lend/earn.md) | [SDK](https://developers.jup.ag/docs/lend/sdk.md) | [OpenAPI](https://developers.jup.ag/docs/openapi-spec/lend/lend.yaml)
+- Refs: [Overview](https://developers.jup.ag/docs/lend/index.md) | [Earn](https://developers.jup.ag/docs/lend/earn.md) | [SDK](https://developers.jup.ag/docs/lend/api-vs-sdk.md) | [OpenAPI](https://developers.jup.ag/docs/openapi-spec/lend/lend.yaml)
 
 ---
 
@@ -192,8 +196,8 @@ Common error codes returned by `/swap/v2/execute` with recommended actions:
 - **Endpoints**: `/auth/challenge` (POST, body: `walletPubkey` + `type`), `/auth/verify` (POST, body: `type` + `walletPubkey` + base58 `signature`), `/vault` (GET), `/vault/register` (GET), `/deposit/craft` (POST), `/orders/price` (POST create, PATCH update), `/orders/price/cancel/{orderId}` (POST, initiates withdrawal), `/orders/price/confirm-cancel/{orderId}` (POST, submits signed withdrawal + `cancelRequestId`), `/orders/history` (GET, wallet implicit via JWT)
 - **Order types**: `single` (one directional trigger), `oco` (take-profit + stop-loss pair), `otoco` (entry trigger + OCO). `triggerCondition`: `"above"` or `"below"`.
 - **Architecture**: Off-chain custodial vault (Privy) per wallet. Orders invisible on-chain until execution — MEV-resistant. Triggers on USD price (not pool rate ratios). Partial fills supported.
-- **Gotchas**: Order creation is 3 steps — `GET /vault/register` (register if new), `POST /deposit/craft` (returns `transaction` + `requestId`), sign deposit tx, then `POST /orders/price` with `depositRequestId` + `depositSignedTx`. Cancellation is two-step — `POST /cancel/{orderId}` returns `transaction` + `requestId`; sign, then `POST /confirm-cancel/{orderId}` with `signedTransaction` + `cancelRequestId`. Response field is `id` (not `orderId`).
-- Refs: [Overview](https://developers.jup.ag/docs/trigger/index.md) | [Create order](https://developers.jup.ag/docs/trigger/create-order.md) | [Order history](https://developers.jup.ag/docs/trigger/order-history.md) | [Manage orders](https://developers.jup.ag/docs/trigger/manage-orders.md) | [OpenAPI](https://developers.jup.ag/docs/openapi-spec/trigger/v2/trigger.yaml)
+- **Gotchas**: Order creation is 3 steps — `GET /vault/register` (register if new; returns `409 "Vault already registered"` if it exists, which is fine), `POST /deposit/craft` (returns `transaction` + `requestId`; the body MUST include `orderType: "price"` and `orderSubType` (`single`/`oco`/`otoco`)), sign deposit tx, then `POST /orders/price` with `depositRequestId` + `depositSignedTx`. Cancellation is two-step — `POST /cancel/{orderId}` returns `transaction` + `requestId`; sign, then `POST /confirm-cancel/{orderId}` with `signedTransaction` + `cancelRequestId`. Create response field is `id` (not `orderId`); order history objects use `orderState`/`rawState` (no `status` field).
+- Refs: [Overview](https://developers.jup.ag/docs/trigger/index.md) | [Authentication](https://developers.jup.ag/docs/trigger/authentication.md) | [Create order](https://developers.jup.ag/docs/trigger/create-order.md) | [Order history](https://developers.jup.ag/docs/trigger/order-history.md) | [Manage orders](https://developers.jup.ag/docs/trigger/manage-orders.md) | [OpenAPI](https://developers.jup.ag/docs/openapi-spec/trigger/v2/trigger.yaml)
 
 ---
 
@@ -215,8 +219,8 @@ Common error codes returned by `/swap/v2/execute` with recommended actions:
 - **Base URL**: `https://api.jup.ag/tokens/v2`
 - **Triggers**: `token metadata`, `token search`, `shield`
 - **Endpoints**: `/search?query={q}` (GET, comma-separate mints, max 100), `/tag?query={tag}` (GET, `verified` or `lst`), `/{category}/{interval}` (GET, categories: `toporganicscore`, `toptraded`, `toptrending`; intervals: `5m`, `1h`, `6h`, `24h`), `/recent` (GET)
-- **Gotchas**: Use mint address as primary identity; treat symbol/name as convenience. Surface `audit.isSus` and `organicScore` in UX.
-- Refs: [Overview](https://developers.jup.ag/docs/tokens/index.md) | [Token info v2](https://developers.jup.ag/docs/tokens/v2/token-information.md) | [OpenAPI](https://developers.jup.ag/docs/openapi-spec/tokens/v2/tokens.yaml)
+- **Gotchas**: Use mint address as primary identity; treat symbol/name as convenience. Primary trust signal is top-level `isVerified` (boolean) plus `organicScore` (0-100) and `organicScoreLabel` (`high`/`medium`/`low`). Secondary risk flag: **`audit.isSus`** — a boolean present ONLY when `true` (a safe token has no `isSus` key at all), so check it defensively as `token.audit?.isSus === true`, never read it directly. Verified live on flagged tokens (dev holds ~100% of supply); those also carry `isVerified: null` and `organicScoreLabel: "low"`. Absence of `isSus` is NOT proof of safety — not all risky tokens carry the flag. Other conditional `audit` fields the live API returns: `mintAuthorityDisabled`, `freezeAuthorityDisabled`, `topHoldersPercentage`, `devBalancePercentage`, `devMigrations`, `devMints` (all nullable, any may be absent; `devMigrations` is returned but missing from the current OpenAPI schema).
+- Refs: [Overview](https://developers.jup.ag/docs/tokens/index.md) | [Token info v2](https://developers.jup.ag/docs/tokens/token-information.md) | [OpenAPI](https://developers.jup.ag/docs/openapi-spec/tokens/v2/tokens.yaml)
 
 ---
 
@@ -226,8 +230,9 @@ Common error codes returned by `/swap/v2/execute` with recommended actions:
 - **Triggers**: `price`, `valuation`, `price feed`
 - **Limit**: Max 50 mint IDs per request
 - **Endpoints**: `/price/v3?ids={mints}` (GET, comma-separated)
-- **Gotchas**: Tokens with unreliable pricing return `null` or are omitted (not an error). Fail closed on missing/low-confidence data for safety-sensitive actions. Use `confidenceLevel` field.
-- Refs: [Overview](https://developers.jup.ag/docs/price/index.md) | [Price v3](https://developers.jup.ag/docs/price/v3.md) | [OpenAPI](https://developers.jup.ag/docs/openapi-spec/price/v3/price.yaml)
+- **Response**: keyed by mint, each value has `usdPrice`, `blockId`, `decimals`, `priceChange24h`, `liquidity`, `createdAt` (some tokens add conditional fields like `launchpad`, `stockData`, `scaledUiConfig`). Price API V3 has NO `confidenceLevel` field (that was V2).
+- **Gotchas**: Tokens with unreliable pricing are omitted from the response entirely (not an error, no `null` placeholder). Fail closed when a requested mint is missing from the response for safety-sensitive actions. Use `blockId` to check price recency.
+- Refs: [Overview](https://developers.jup.ag/docs/price/index.md) | [OpenAPI](https://developers.jup.ag/docs/openapi-spec/price/v3/price.yaml)
 
 ---
 
@@ -250,8 +255,9 @@ Common error codes returned by `/swap/v2/execute` with recommended actions:
 - **Price convention**: 1,000,000 native units = $1.00 USD
 - **Triggers**: `prediction markets`, `market odds`, `event market`
 - **Deposit mints**: JupUSD (`JuprjznTrTSp2UFa3ZBUFgwdAmtZCq4MQCwysN55USD`), USDC
-- **Endpoints**: `/events` (GET), `/events/search` (GET), `/markets/{marketId}` (GET), `/orderbook/{marketId}` (GET), `/orders` (POST), `/orders/status/{pubkey}` (GET), `/positions` (GET), `/positions/{pubkey}` (DELETE), `/positions/{pubkey}/claim` (POST), `/history` (GET), `/leaderboards` (GET)
-- **Gotchas**: Check `position.claimable` before claiming. Winners get $1/contract.
+- **Min order**: $5 (5,000,000 native units)
+- **Endpoints**: `/events` (GET, returns `{data, pagination}`), `/events/search` (GET), `/markets/{marketId}` (GET), `/orderbook/{marketId}` (GET, returns `{yes, no, yes_dollars, no_dollars}`), `/orders` (POST, requires `isBuy` boolean + `ownerPubkey`), `/orders/status/{orderPubkey}` (GET), `/positions` (GET, `?ownerPubkey=`), `/positions/{positionPubkey}` (DELETE), `/positions/{positionPubkey}/claim` (POST), `/history` (GET), `/leaderboards` (GET)
+- **Gotchas**: Check `position.claimable` before claiming. Winners get $1/contract. Markets are FLAT (fields like `provider`, `marketId`, `result`, `resolveAt`, `outcomes`, `clobTokenIds` live at the top level, not nested under `metadata`). Contracts are fractional: use `contractsMicro` (1,000,000 = 1 contract) or `contractsDecimal`, not the legacy whole-number `contracts`.
 - Refs: [Overview](https://developers.jup.ag/docs/prediction/index.md) | [Events](https://developers.jup.ag/docs/prediction/events-and-markets.md) | [Positions](https://developers.jup.ag/docs/prediction/open-positions.md) | [OpenAPI](https://developers.jup.ag/docs/openapi-spec/prediction/prediction.yaml)
 
 ---
@@ -296,11 +302,11 @@ Common error codes returned by `/swap/v2/execute` with recommended actions:
 ### Routing
 
 - **Triggers**: `dex integration`, `rfq integration`, `routing engine`
-- **Engines**: Juno (meta-aggregator), Iris (multi-hop DEX routing, powers Swap API), JupiterZ (RFQ market maker quotes)
-- **DEX Integration** (into Iris): Free, no fees. Prereqs: code health, security audit, market traction. Implement `jupiter-amm-interface` crate. **Critical**: No network calls in implementation (accounts are pre-batched and cached). Ref impl: [github.com/jup-ag/rust-amm-implementation](https://github.com/jup-ag/rust-amm-implementation)
+- **Engines**: Juno (meta-aggregator), Metis (multi-hop DEX routing, powers the Swap API; formerly called Iris), JupiterZ (RFQ market maker quotes)
+- **DEX Integration** (into Metis): Free, no fees. Prereqs: code health, security audit, market traction. Implement `jupiter-amm-interface` crate. **Critical**: No network calls in implementation (accounts are pre-batched and cached). Ref impl: [github.com/jup-ag/rust-amm-implementation](https://github.com/jup-ag/rust-amm-implementation)
 - **RFQ Integration** (JupiterZ): Market makers host webhook at `/jupiter/rfq/quote` (POST, 250ms), `/jupiter/rfq/swap` (POST), `/jupiter/rfq/tokens` (GET). Reqs: 95% fill rate, 250ms response, 55s expiry. SDK: [github.com/jup-ag/rfq-webhook-toolkit](https://github.com/jup-ag/rfq-webhook-toolkit)
 - **Market Listing**: Instant routing for tokens < 30 days old. Normal routing (checked every 30 min) requires < 30% loss on $500 round-trip OR < 20% price impact comparing $1k vs $500.
-- Refs: [Overview](https://developers.jup.ag/docs/routing/index.md) | [DEX integration](https://developers.jup.ag/docs/routing/dex-integration.md) | [RFQ integration](https://developers.jup.ag/docs/routing/rfq-integration.md) | [Market listing](https://developers.jup.ag/docs/routing/market-listing.md)
+- Refs: [DEX integration](https://developers.jup.ag/docs/swap/routing/dex-integration.md) | [RFQ integration](https://developers.jup.ag/docs/swap/routing/rfq-integration.md) | [Market listing](https://developers.jup.ag/docs/swap/routing/market-listing.md)
 
 ---
 
@@ -317,7 +323,7 @@ Common error codes returned by `/swap/v2/execute` with recommended actions:
 
 Quotas recalculate every 10 minutes. Pro plan does NOT increase Swap API limits.
 
-**Other APIs**: Managed at portal level. Check [portal rate limits](https://developers.jup.ag/docs/portal/rate-limit.md).
+**Other APIs**: Managed at portal level. Check [portal rate limits](https://developers.jup.ag/docs/portal/rate-limits.md).
 
 **On HTTP 429**: Exponential backoff with jitter: `delay = min(baseDelay * 2^attempt + random(0, jitter), maxDelay)`. Wait for 10s sliding window refresh. Do NOT burst aggressively.
 
@@ -338,7 +344,7 @@ Quotas recalculate every 10 minutes. Pro plan does NOT increase Swap API limits.
 
 1. Start from the API-specific overview before coding endpoint calls.
 2. Enforce auth as a hard precondition for every request. Ref: [Portal setup](https://developers.jup.ag/docs/portal/setup.md)
-3. Design retry logic around documented rate-limit behavior, not fixed assumptions. Ref: [Rate limits](https://developers.jup.ag/docs/portal/rate-limit.md)
+3. Design retry logic around documented rate-limit behavior, not fixed assumptions. Ref: [Rate limits](https://developers.jup.ag/docs/portal/rate-limits.md)
 4. Map all non-success responses to typed app errors using documented response semantics. Ref: [API responses](https://developers.jup.ag/docs/portal/responses.md)
 5. For order-based products (Swap/Trigger/Recurring), separate create/execute/retrieve phases in code and logs.
 6. Treat network/service health as part of runtime behavior (degrade gracefully). Ref: [Status page](https://status.jup.ag/)
@@ -416,10 +422,10 @@ Always fetch the freshest context from referenced docs/specs before executing a 
 ## Operational References
 
 - [Portal setup](https://developers.jup.ag/docs/portal/setup.md) — API key configuration
-- [Rate limits](https://developers.jup.ag/docs/portal/rate-limit.md) — Global rate limit policy
-- [Swap routing](https://developers.jup.ag/docs/swap/v2/routing.md) — Router competition and parameter impact
+- [Rate limits](https://developers.jup.ag/docs/portal/rate-limits.md) — Global rate limit policy
+- [Swap overview](https://developers.jup.ag/docs/swap/index.md) — Router competition and parameter impact
 - [API responses](https://developers.jup.ag/docs/portal/responses.md) — Response format standards
-- [Swap order & execute](https://developers.jup.ag/docs/swap/v2/order-and-execute.md) — Detailed error codes and response format
+- [Swap order & execute](https://developers.jup.ag/docs/swap/order-and-execute.md) — Detailed error codes and response format
 - [Status page](https://status.jup.ag/) — Service health
 - [Documentation sitemap](https://developers.jup.ag/docs/llms.txt) — Full docs index
 - [Tool Kits](https://developers.jup.ag/docs/tool-kits/plugin/index.md) — Plugin, Wallet Kit, Referral Program

--- a/.plugins/integrate-jupiter/codex/skills/integrating-jupiter/SKILL.md
+++ b/.plugins/integrate-jupiter/codex/skills/integrating-jupiter/SKILL.md
@@ -4,7 +4,7 @@ description: Comprehensive guidance for integrating Jupiter APIs (Swap, Lend, Pe
 license: MIT
 metadata:
   author: jup-ag
-  version: "1.1.0"
+  version: "1.1.1"
 tags:
   - jupiter
   - jup-ag
@@ -131,9 +131,13 @@ Use each block as a minimal execution contract. Fetch the linked refs for full r
 - **Fee**: Variable by pair — 0 bps (Jupiter tokens/pegged), 2 bps (SOL-Stable), 5 bps (LST-Stable), 10 bps (most pairs), 50 bps (tokens < 24h). Referral fees: 50-255 bps (Jupiter retains 20%).
 - **Rate Limit**: 50 req/10s base, scales with 24h execute volume (see [Rate Limits](#rate-limits))
 - **Endpoints**: `/order` (GET), `/execute` (POST), `/build` (GET, Metis-only raw instructions)
-- **Routing**: 4 routers compete — Metis (`metis`), JupiterZ (`jupiterz`), Dflow (`dflow`), OKX (`okx`). The `router` response field returns one of these values (`metis`, not the legacy `iris`). `swapType` is `aggregator` (Metis, Dflow, or OKX) or `rfq` (JupiterZ). Response `mode` field: `"ultra"` (all routers, default params) or `"manual"` (restricted by optional params). `/build` uses Metis only.
+- **Routing**: 4 routers compete — Metis (`metis`), JupiterZ (`jupiterz`), Dflow (`dflow`), OKX (`okx`). The `router` response field returns one of these values. `swapType` is `aggregator` (Metis, Dflow, or OKX) or `rfq` (JupiterZ). Response `mode` field: `"ultra"` (all routers, default params) or `"manual"` (restricted by optional params). `/build` uses Metis only.
 - **Gasless**: Three paths — automatic (Jupiter-covered), JupiterZ (MM-covered), integrator-payer (`payer` param, Metis-only routing). Eligibility varies by balance, trade size, and parameters used. See [Gasless docs](https://developers.jup.ag/docs/swap/advanced/gasless.md) for current thresholds and disqualifying params.
-- **Gotchas**: Signed payloads have ~2 min TTL. Transactions are immutable after receipt. Split order/execute in code and logging. Re-quote before execution when conditions may have changed. Routing impact of optional params: `referralAccount` + `referralFee` disable JupiterZ only (Metis/Dflow/OKX remain); `payer` (integrator gasless) restricts routing to Metis only (disables JupiterZ, Dflow, and OKX); `receiver` does NOT restrict routing, but must differ from `taker` (`receiver=taker` returns `400 "Receiver cannot be same as taker"`). `/build` transactions cannot use `/execute` — self-manage via RPC.
+- **Gotchas**:
+  - Signed payloads have ~2 min TTL. Transactions are immutable after receipt.
+  - Split order/execute in code and logging. Re-quote before execution when conditions may have changed.
+  - Routing impact of optional params: `referralAccount` + `referralFee` disable JupiterZ only (Metis/Dflow/OKX remain); `payer` (integrator gasless) restricts routing to Metis only (disables JupiterZ, Dflow, and OKX); `receiver` does NOT restrict routing, but must differ from `taker` (`receiver=taker` returns `400 "Receiver cannot be same as taker"`).
+  - `/build` transactions cannot use `/execute` — self-manage via RPC.
 - **Migrating from an older integration?** Use the `jupiter-swap-migration` skill.
 - Refs: [Overview](https://developers.jup.ag/docs/swap/index.md) | [Order & Execute](https://developers.jup.ag/docs/swap/order-and-execute.md) | [Build](https://developers.jup.ag/docs/swap/build/index.md) | [Gasless](https://developers.jup.ag/docs/swap/advanced/gasless.md) | [Migration](https://developers.jup.ag/docs/swap/migration/ultra-to-order.md) | [OpenAPI](https://developers.jup.ag/docs/openapi-spec/swap/v2/swap.yaml)
 
@@ -196,7 +200,10 @@ On success, `/execute` returns `{ status: "Success", code: 0, signature, inputAm
 - **Endpoints**: `/auth/challenge` (POST, body: `walletPubkey` + `type`), `/auth/verify` (POST, body: `type` + `walletPubkey` + base58 `signature`), `/vault` (GET), `/vault/register` (GET), `/deposit/craft` (POST), `/orders/price` (POST create, PATCH update), `/orders/price/cancel/{orderId}` (POST, initiates withdrawal), `/orders/price/confirm-cancel/{orderId}` (POST, submits signed withdrawal + `cancelRequestId`), `/orders/history` (GET, wallet implicit via JWT)
 - **Order types**: `single` (one directional trigger), `oco` (take-profit + stop-loss pair), `otoco` (entry trigger + OCO). `triggerCondition`: `"above"` or `"below"`.
 - **Architecture**: Off-chain custodial vault (Privy) per wallet. Orders invisible on-chain until execution — MEV-resistant. Triggers on USD price (not pool rate ratios). Partial fills supported.
-- **Gotchas**: Order creation is 3 steps — `GET /vault/register` (register if new; returns `409 "Vault already registered"` if it exists, which is fine), `POST /deposit/craft` (returns `transaction` + `requestId`; the body MUST include `orderType: "price"` and `orderSubType` (`single`/`oco`/`otoco`)), sign deposit tx, then `POST /orders/price` with `depositRequestId` + `depositSignedTx`. Cancellation is two-step — `POST /cancel/{orderId}` returns `transaction` + `requestId`; sign, then `POST /confirm-cancel/{orderId}` with `signedTransaction` + `cancelRequestId`. Create response field is `id` (not `orderId`); order history objects use `orderState`/`rawState` (no `status` field).
+- **Gotchas**:
+  - Order creation is 3 steps — `GET /vault/register` (register if new; returns `409 "Vault already registered"` if it exists, which is fine), `POST /deposit/craft` (returns `transaction` + `requestId`; the body MUST include `orderType: "price"` and `orderSubType` (`single`/`oco`/`otoco`)), sign deposit tx, then `POST /orders/price` with `depositRequestId` + `depositSignedTx`.
+  - Cancellation is two-step — `POST /cancel/{orderId}` returns `transaction` + `requestId`; sign, then `POST /confirm-cancel/{orderId}` with `signedTransaction` + `cancelRequestId`.
+  - Create response field is `id` (not `orderId`); order history objects use `orderState`/`rawState` (no `status` field).
 - Refs: [Overview](https://developers.jup.ag/docs/trigger/index.md) | [Authentication](https://developers.jup.ag/docs/trigger/authentication.md) | [Create order](https://developers.jup.ag/docs/trigger/create-order.md) | [Order history](https://developers.jup.ag/docs/trigger/order-history.md) | [Manage orders](https://developers.jup.ag/docs/trigger/manage-orders.md) | [OpenAPI](https://developers.jup.ag/docs/openapi-spec/trigger/v2/trigger.yaml)
 
 ---
@@ -219,7 +226,11 @@ On success, `/execute` returns `{ status: "Success", code: 0, signature, inputAm
 - **Base URL**: `https://api.jup.ag/tokens/v2`
 - **Triggers**: `token metadata`, `token search`, `shield`
 - **Endpoints**: `/search?query={q}` (GET, comma-separate mints, max 100), `/tag?query={tag}` (GET, `verified` or `lst`), `/{category}/{interval}` (GET, categories: `toporganicscore`, `toptraded`, `toptrending`; intervals: `5m`, `1h`, `6h`, `24h`), `/recent` (GET)
-- **Gotchas**: Use mint address as primary identity; treat symbol/name as convenience. Primary trust signal is top-level `isVerified` (boolean) plus `organicScore` (0-100) and `organicScoreLabel` (`high`/`medium`/`low`). Secondary risk flag: **`audit.isSus`** — a boolean present ONLY when `true` (a safe token has no `isSus` key at all), so check it defensively as `token.audit?.isSus === true`, never read it directly. Verified live on flagged tokens (dev holds ~100% of supply); those also carry `isVerified: null` and `organicScoreLabel: "low"`. Absence of `isSus` is NOT proof of safety — not all risky tokens carry the flag. Other conditional `audit` fields the live API returns: `mintAuthorityDisabled`, `freezeAuthorityDisabled`, `topHoldersPercentage`, `devBalancePercentage`, `devMigrations`, `devMints` (all nullable, any may be absent; `devMigrations` is returned but missing from the current OpenAPI schema).
+- **Gotchas**:
+  - Use mint address as primary identity; treat symbol/name as convenience.
+  - Primary trust signal is top-level `isVerified` (boolean) plus `organicScore` (0-100) and `organicScoreLabel` (`high`/`medium`/`low`).
+  - Secondary risk flag: **`audit.isSus`** — a boolean present ONLY when `true` (a safe token has no `isSus` key at all), so check it defensively as `token.audit?.isSus === true`, never read it directly. Verified live on flagged tokens (dev holds ~100% of supply); those also carry `isVerified: null` and `organicScoreLabel: "low"`. Absence of `isSus` is NOT proof of safety — not all risky tokens carry the flag.
+  - Other conditional `audit` fields the live API returns: `mintAuthorityDisabled`, `freezeAuthorityDisabled`, `topHoldersPercentage`, `devBalancePercentage`, `devMigrations`, `devMints` (all nullable, any may be absent; `devMigrations` is returned but missing from the current OpenAPI schema).
 - Refs: [Overview](https://developers.jup.ag/docs/tokens/index.md) | [Token info v2](https://developers.jup.ag/docs/tokens/token-information.md) | [OpenAPI](https://developers.jup.ag/docs/openapi-spec/tokens/v2/tokens.yaml)
 
 ---
@@ -257,7 +268,10 @@ On success, `/execute` returns `{ status: "Success", code: 0, signature, inputAm
 - **Deposit mints**: JupUSD (`JuprjznTrTSp2UFa3ZBUFgwdAmtZCq4MQCwysN55USD`), USDC
 - **Min order**: $5 (5,000,000 native units)
 - **Endpoints**: `/events` (GET, returns `{data, pagination}`), `/events/search` (GET), `/markets/{marketId}` (GET), `/orderbook/{marketId}` (GET, returns `{yes, no, yes_dollars, no_dollars}`), `/orders` (POST, requires `isBuy` boolean + `ownerPubkey`), `/orders/status/{orderPubkey}` (GET), `/positions` (GET, `?ownerPubkey=`), `/positions/{positionPubkey}` (DELETE), `/positions/{positionPubkey}/claim` (POST), `/history` (GET), `/leaderboards` (GET)
-- **Gotchas**: Check `position.claimable` before claiming. Winners get $1/contract. Markets are FLAT (fields like `provider`, `marketId`, `result`, `resolveAt`, `outcomes`, `clobTokenIds` live at the top level, not nested under `metadata`). Contracts are fractional: use `contractsMicro` (1,000,000 = 1 contract) or `contractsDecimal`, not the legacy whole-number `contracts`.
+- **Gotchas**:
+  - Check `position.claimable` before claiming. Winners get $1/contract.
+  - Markets are FLAT — fields like `provider`, `marketId`, `result`, `resolveAt`, `outcomes`, `clobTokenIds` live at the top level, not nested under `metadata`.
+  - Contracts are fractional: use `contractsMicro` (1,000,000 = 1 contract) or `contractsDecimal`, not the legacy whole-number `contracts`.
 - Refs: [Overview](https://developers.jup.ag/docs/prediction/index.md) | [Events](https://developers.jup.ag/docs/prediction/events-and-markets.md) | [Positions](https://developers.jup.ag/docs/prediction/open-positions.md) | [OpenAPI](https://developers.jup.ag/docs/openapi-spec/prediction/prediction.yaml)
 
 ---

--- a/.plugins/integrate-jupiter/codex/skills/integrating-jupiter/examples/price.md
+++ b/.plugins/integrate-jupiter/codex/skills/integrating-jupiter/examples/price.md
@@ -14,35 +14,35 @@ const SOL_MINT = 'So11111111111111111111111111111111111111112';
 const USDC_MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
 const WBTC_MINT = '3NZ9JMVBmGAqocybic2c7LQCJScmgsAZ6vQqTDzcqmJh';
 
-async function getPrices(mints: string[], confidenceLevel: 'low' | 'medium' | 'high' = 'medium') {
-  const ids = mints.join(',');
+// Price API V3 response is keyed by mint. Each entry has usdPrice (number),
+// blockId, decimals, priceChange24h, and liquidity. There is NO confidenceLevel
+// field (that was V2). Mints with no reliable price are OMITTED from the
+// response entirely — there is no null placeholder — so treat a missing mint
+// as "unpriced" and fail closed for safety-sensitive actions.
+type PriceEntry = {
+  usdPrice: number;
+  blockId: number;
+  decimals: number;
+  priceChange24h: number;
+  liquidity?: number;
+};
 
-  const data = await jupiterFetch<{
-    data: Record<string, { price: string; confidenceLevel?: string } | null>;
-  }>(`/price/v3?ids=${encodeURIComponent(ids)}`);
+async function getPrices(mints: string[]) {
+  const ids = mints.join(','); // max 50 mints per request
 
-  const prices: Record<string, { price: number; confidence: string } | null> = {};
+  const data = await jupiterFetch<Record<string, PriceEntry>>(
+    `/price/v3?ids=${encodeURIComponent(ids)}`,
+  );
 
+  const prices: Record<string, PriceEntry | null> = {};
   for (const mint of mints) {
-    const entry = data.data?.[mint];
-    if (!entry || !entry.price) {
-      prices[mint] = null; // token not priced or unreliable
-      continue;
-    }
-
-    // Filter by confidence — fail closed on low-confidence data
-    const levels = ['low', 'medium', 'high'];
-    const entryLevel = entry.confidenceLevel || 'low';
-    if (levels.indexOf(entryLevel) < levels.indexOf(confidenceLevel)) {
-      prices[mint] = null;
-      continue;
-    }
-
-    prices[mint] = { price: parseFloat(entry.price), confidence: entryLevel };
+    // Missing mint => no reliable price. Fail closed.
+    prices[mint] = data[mint] ?? null;
   }
-
   return prices;
 }
 
-// Usage: getPrices([SOL_MINT, USDC_MINT, WBTC_MINT])
+// Usage:
+// const prices = await getPrices([SOL_MINT, USDC_MINT, WBTC_MINT]);
+// const solUsd = prices[SOL_MINT]?.usdPrice; // number | undefined
 ```

--- a/.plugins/integrate-jupiter/codex/skills/integrating-jupiter/examples/trigger.md
+++ b/.plugins/integrate-jupiter/codex/skills/integrating-jupiter/examples/trigger.md
@@ -93,6 +93,8 @@ async function craftDeposit(jwt: string, inputMint: string, amount: string) {
       outputMint: USDC_MINT,    // destination token for the order
       userAddress: wallet.publicKey.toBase58(),
       amount,
+      orderType: 'price',       // required
+      orderSubType: 'single',   // required: match the order you will create (single | oco | otoco)
     }),
   });
 

--- a/.plugins/integrate-jupiter/codex/skills/jupiter-lend/SKILL.md
+++ b/.plugins/integrate-jupiter/codex/skills/jupiter-lend/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: jupiter-lend
-version: 0.1.2
+version: 0.1.3
 description: Interact with Jupiter Lend Protocol. Read-only SDK (@jup-ag/lend-read) for querying liquidity pools, lending markets (jlTokens), and vaults. Write SDK (@jup-ag/lend) for lending (deposit/withdraw) and vault operations (deposit collateral, borrow, repay, manage positions).
 homepage: https://jup.ag/lend
 metadata:
@@ -359,9 +359,9 @@ The Jupiter Lend Build Kit offers developer components, powerful utilities, and 
 - **Wallet integrations (Privy)**: [Earn with Privy](https://developers.jup.ag/docs/lend/wallets/privy-earn), [Borrow with Privy](https://developers.jup.ag/docs/lend/wallets/privy-borrow)
 - **Borrow**: [overview](https://developers.jup.ag/docs/lend/borrow), [create position](https://developers.jup.ag/docs/lend/borrow/create-position), [deposit](https://developers.jup.ag/docs/lend/borrow/deposit), [borrow](https://developers.jup.ag/docs/lend/borrow/borrow), [repay](https://developers.jup.ag/docs/lend/borrow/repay), [withdraw](https://developers.jup.ag/docs/lend/borrow/withdraw), [combined operate](https://developers.jup.ag/docs/lend/borrow/combined), [liquidate](https://developers.jup.ag/docs/lend/borrow/liquidation), [read vault data](https://developers.jup.ag/docs/lend/borrow/read-vault-data)
 - **Flashloan**: [overview](https://developers.jup.ag/docs/lend/flashloan), [execute](https://developers.jup.ag/docs/lend/flashloan/execute)
-- **Advanced**: [advanced/multiply](https://developers.jup.ag/docs/lend/advanced/multiply), [advanced/unwind](https://developers.jup.ag/docs/lend/advanced/unwind), [advanced/repay-withdraw-collateral](https://developers.jup.ag/docs/lend/advanced/repay-with-collateral-max-withdraw), [advanced/vault-swap](https://developers.jup.ag/docs/lend/advanced/vault-swap), [advanced/utilization-after-deposit](https://developers.jup.ag/docs/lend/advanced/utilization-after-deposit), [advanced/native-staked-vault/overview](https://developers.jup.ag/docs/lend/advanced/native-staked-vault/overview), [advanced/native-staked-vault/deposit](https://developers.jup.ag/docs/lend/advanced/native-staked-vault/deposit), [advanced/native-staked-vault/withdraw](https://developers.jup.ag/docs/lend/advanced/native-staked-vault/withdraw)
+- **Advanced**: [advanced/multiply](https://developers.jup.ag/docs/lend/advanced/multiply), [advanced/unwind](https://developers.jup.ag/docs/lend/advanced/unwind), [advanced/repay-withdraw-collateral](https://developers.jup.ag/docs/lend/advanced/repay-with-collateral-max-withdraw), [advanced/vault-swap](https://developers.jup.ag/docs/lend/advanced/vault-swap), [advanced/utilization-after-deposit](https://developers.jup.ag/docs/lend/advanced/utilization-after-deposit), [advanced/native-staked-vault/overview](https://developers.jup.ag/docs/lend/advanced/native-staked-vault), [advanced/native-staked-vault/deposit](https://developers.jup.ag/docs/lend/advanced/native-staked-vault/deposit), [advanced/native-staked-vault/withdraw](https://developers.jup.ag/docs/lend/advanced/native-staked-vault/withdraw)
 - **Liquidity**: [liquidity/analytics](https://developers.jup.ag/docs/lend/liquidity/analytics)
-- **Resources**: [resources/program-addresses](https://developers.jup.ag/docs/lend/resources/program-addresses), [resources/idl-and-types](https://developers.jup.ag/docs/lend/resources/idl-and-types), [resources/dune](https://developers.jup.ag/docs/lend/resources/dune)
+- **Resources**: [resources/program-addresses](https://developers.jup.ag/docs/lend/program-addresses), [resources/idl-and-types](https://developers.jup.ag/docs/lend/idl-and-types), [resources/dune](https://developers.jup.ag/docs/lend/dune)
 
 ---
 

--- a/.plugins/integrate-jupiter/codex/skills/jupiter-swap-migration/SKILL.md
+++ b/.plugins/integrate-jupiter/codex/skills/jupiter-swap-migration/SKILL.md
@@ -4,7 +4,7 @@ description: Migration guide from Jupiter Metis (v1) or Ultra to Swap API v2. Us
 license: MIT
 metadata:
   author: jup-ag
-  version: "1.0.1"
+  version: "1.1.0"
 tags:
   - jupiter
   - swap-migration
@@ -64,7 +64,7 @@ Each path has a dedicated example with before/after code, parameter mappings, an
 6. **ALT handling**: If using `/build`, switch from `addressLookupTableAddresses` (array) to `addressesByLookupTableAddress` (object) — remove RPC ALT resolution code
 7. **Fee event parsing**: V2 instructions don't emit fee events — update any transaction parser that depends on them
 8. **Route plan format**: If parsing route plans, use `bps` field (canonical) instead of `percent`
-9. **Error codes**: Update error handling to match [Swap v2 error codes](https://developers.jup.ag/docs/swap/v2/order-and-execute.md)
+9. **Error codes**: Update error handling to match [Swap v2 error codes](https://developers.jup.ag/docs/swap/order-and-execute.md)
 10. **Test**: Run end-to-end swap on devnet/mainnet with small amount to verify
 
 ## Sunset
@@ -75,9 +75,12 @@ Remove this skill once Jupiter decommissions the v1 (`/swap/v1`) endpoints and t
 
 ## References
 
-- [Migration guide](https://developers.jup.ag/docs/swap/v2/migration.md)
-- [Order & Execute](https://developers.jup.ag/docs/swap/v2/order-and-execute.md)
-- [Build](https://developers.jup.ag/docs/swap/v2/build/index.md)
-- [Fees](https://developers.jup.ag/docs/swap/v2/fees.md)
-- [Routing](https://developers.jup.ag/docs/swap/v2/routing.md)
+Migration is split into three profile-targeted guides (the old single `migration` page no longer exists):
+
+- [Migration: Ultra → /order](https://developers.jup.ag/docs/swap/migration/ultra-to-order.md)
+- [Migration: Metis → /build](https://developers.jup.ag/docs/swap/migration/metis-to-build.md)
+- [Migration: Metis → Meta-Aggregator (/order + /execute)](https://developers.jup.ag/docs/swap/migration/metis-to-meta-aggregator.md)
+- [Order & Execute](https://developers.jup.ag/docs/swap/order-and-execute.md)
+- [Build](https://developers.jup.ag/docs/swap/build/index.md)
+- [Swap overview](https://developers.jup.ag/docs/swap/index.md) (routing and fees)
 - [OpenAPI spec](https://developers.jup.ag/docs/openapi-spec/swap/v2/swap.yaml)

--- a/.plugins/integrate-jupiter/codex/skills/jupiter-swap-migration/examples/ultra-to-order.md
+++ b/.plugins/integrate-jupiter/codex/skills/jupiter-swap-migration/examples/ultra-to-order.md
@@ -53,7 +53,7 @@ const result = await fetch(`${BASE_URL}/execute`, {
 ## New response fields
 
 The v2 `/order` response now also includes:
-- `router` — which router won: `"iris"`, `"jupiterz"`, `"dflow"`, or `"okx"`
+- `router` — which router won: `"metis"`, `"jupiterz"`, `"dflow"`, or `"okx"`
 - `mode` — `"ultra"` (all routers competed) or `"manual"` (optional params restricted routing)
 - `feeBps` — fee basis points applied
 - `feeMint` — mint of the fee token

--- a/skills/integrating-jupiter/README.md
+++ b/skills/integrating-jupiter/README.md
@@ -20,7 +20,7 @@ Skills for AI coding agents in the Jupiter ecosystem.
 | Send | Token transfers via invite links |
 | Studio | Token creation with Dynamic Bonding Curves |
 | Lock | Token vesting and lock (on-chain program) |
-| Routing | DEX aggregation (Iris), RFQ (JupiterZ), and market listing |
+| Routing | DEX aggregation (Metis), RFQ (JupiterZ), and market listing |
 
 ## Examples
 
@@ -28,7 +28,7 @@ Production-ready code snippets in `examples/`:
 - `swap.md` — Swap order → sign → execute → confirm
 - `lend.md` — USDC deposit into Jupiter Lend
 - `trigger.md` — Create and execute a limit order
-- `price.md` — Multi-token price lookup with confidence filtering
+- `price.md` — Multi-token price lookup with fail-closed handling for unpriced mints
 
 ## Related skills
 

--- a/skills/integrating-jupiter/SKILL.md
+++ b/skills/integrating-jupiter/SKILL.md
@@ -4,7 +4,7 @@ description: Comprehensive guidance for integrating Jupiter APIs (Swap, Lend, Pe
 license: MIT
 metadata:
   author: jup-ag
-  version: "1.0.0"
+  version: "1.1.0"
 tags:
   - jupiter
   - jup-ag
@@ -27,7 +27,7 @@ tags:
   - jupiter-lock
   - jupiter-routing
   - jupiterz-rfq
-  - iris
+  - metis
   - jupiter-price-api
   - jupiter-tokens-api
   - jupiter-portal
@@ -131,11 +131,13 @@ Use each block as a minimal execution contract. Fetch the linked refs for full r
 - **Fee**: Variable by pair — 0 bps (Jupiter tokens/pegged), 2 bps (SOL-Stable), 5 bps (LST-Stable), 10 bps (most pairs), 50 bps (tokens < 24h). Referral fees: 50-255 bps (Jupiter retains 20%).
 - **Rate Limit**: 50 req/10s base, scales with 24h execute volume (see [Rate Limits](#rate-limits))
 - **Endpoints**: `/order` (GET), `/execute` (POST), `/build` (GET, Metis-only raw instructions)
-- **Routing**: 4 routers compete — Metis (API value: `iris`), JupiterZ (`jupiterz`), Dflow (`dflow`), OKX (`okx`). Response `mode` field: `"ultra"` (all routers, default params) or `"manual"` (restricted by optional params). `/build` uses Metis only.
-- **Gasless**: Three paths — automatic (Jupiter-covered), JupiterZ (MM-covered), integrator-payer (`payer` param, Metis-only routing). Eligibility varies by balance, trade size, and parameters used. See [Gasless docs](https://developers.jup.ag/docs/swap/v2/advanced/gasless.md) for current thresholds and disqualifying params.
-- **Gotchas**: Signed payloads have ~2 min TTL. Transactions are immutable after receipt. Split order/execute in code and logging. Re-quote before execution when conditions may have changed. `referralAccount`/`referralFee`/`receiver` disable JupiterZ only (Metis/Dflow/OKX remain). `payer` reduces routing to Metis only (per gasless docs; routing docs group all four as disabling JupiterZ but do not itemize the additional Dflow/OKX restriction). `/build` transactions cannot use `/execute` — self-manage via RPC.
+- **Routing**: 4 routers compete — Metis (`metis`), JupiterZ (`jupiterz`), Dflow (`dflow`), OKX (`okx`). The `router` response field returns one of these values (`metis`, not the legacy `iris`). `swapType` is `aggregator` (Metis, Dflow, or OKX) or `rfq` (JupiterZ). Response `mode` field: `"ultra"` (all routers, default params) or `"manual"` (restricted by optional params). `/build` uses Metis only.
+- **Gasless**: Three paths — automatic (Jupiter-covered), JupiterZ (MM-covered), integrator-payer (`payer` param, Metis-only routing). Eligibility varies by balance, trade size, and parameters used. See [Gasless docs](https://developers.jup.ag/docs/swap/advanced/gasless.md) for current thresholds and disqualifying params.
+- **Gotchas**: Signed payloads have ~2 min TTL. Transactions are immutable after receipt. Split order/execute in code and logging. Re-quote before execution when conditions may have changed. Routing impact of optional params: `referralAccount` + `referralFee` disable JupiterZ only (Metis/Dflow/OKX remain); `payer` (integrator gasless) restricts routing to Metis only (disables JupiterZ, Dflow, and OKX); `receiver` does NOT restrict routing, but must differ from `taker` (`receiver=taker` returns `400 "Receiver cannot be same as taker"`). `/build` transactions cannot use `/execute` — self-manage via RPC.
 - **Migrating from an older integration?** Use the `jupiter-swap-migration` skill.
-- Refs: [Overview](https://developers.jup.ag/docs/swap/index.md) | [Order & Execute](https://developers.jup.ag/docs/swap/v2/order-and-execute.md) | [Build](https://developers.jup.ag/docs/swap/v2/build/index.md) | [Fees](https://developers.jup.ag/docs/swap/v2/fees.md) | [Routing](https://developers.jup.ag/docs/swap/v2/routing.md) | [Gasless](https://developers.jup.ag/docs/swap/v2/advanced/gasless.md) | [Migration](https://developers.jup.ag/docs/swap/v2/migration.md) | [OpenAPI](https://developers.jup.ag/docs/openapi-spec/swap/v2/swap.yaml)
+- Refs: [Overview](https://developers.jup.ag/docs/swap/index.md) | [Order & Execute](https://developers.jup.ag/docs/swap/order-and-execute.md) | [Build](https://developers.jup.ag/docs/swap/build/index.md) | [Gasless](https://developers.jup.ag/docs/swap/advanced/gasless.md) | [Migration](https://developers.jup.ag/docs/swap/migration/ultra-to-order.md) | [OpenAPI](https://developers.jup.ag/docs/openapi-spec/swap/v2/swap.yaml)
+
+  Fees are documented inline on the Order & Execute and Build pages; router competition and the parameter routing-impact matrix are on the Overview and Order & Execute pages.
 
 Common error codes returned by `/swap/v2/execute` with recommended actions:
 
@@ -157,6 +159,8 @@ Common error codes returned by `/swap/v2/execute` with recommended actions:
 | `-2004` | RFQ | Swap rejected | Yes | Re-quote, possibly different route |
 | `429` | Rate limit | Rate limited | Yes | Exponential backoff, wait 10s window |
 
+On success, `/execute` returns `{ status: "Success", code: 0, signature, inputAmountResult, outputAmountResult, slot, totalInputAmount, totalOutputAmount }`. On failure it returns `status: "Failed"` with a non-zero `code` and an `error` string. `inputAmountResult`/`outputAmountResult` are the actual on-chain amounts; reconcile against your quote.
+
 
 ---
 
@@ -169,7 +173,7 @@ Common error codes returned by `/swap/v2/execute` with recommended actions:
 - **Endpoints**: `/earn/deposit` (POST), `/earn/withdraw` (POST), `/earn/mint` (POST), `/earn/redeem` (POST), `/earn/deposit-instructions` (POST), `/earn/withdraw-instructions` (POST), `/earn/tokens` (GET), `/earn/positions` (GET), `/earn/earnings` (GET)
 - **Gotchas**: Recompute account state before each state-changing action. Encode risk checks (health factors, liquidation boundaries) as preconditions. All deposit/withdraw/mint/redeem return base64 unsigned `VersionedTransaction`.
 - **For SDK-level integration** with `@jup-ag/lend` and `@jup-ag/lend-read`, use the `jupiter-lend` skill.
-- Refs: [Overview](https://developers.jup.ag/docs/lend/index.md) | [Earn](https://developers.jup.ag/docs/lend/earn.md) | [SDK](https://developers.jup.ag/docs/lend/sdk.md) | [OpenAPI](https://developers.jup.ag/docs/openapi-spec/lend/lend.yaml)
+- Refs: [Overview](https://developers.jup.ag/docs/lend/index.md) | [Earn](https://developers.jup.ag/docs/lend/earn.md) | [SDK](https://developers.jup.ag/docs/lend/api-vs-sdk.md) | [OpenAPI](https://developers.jup.ag/docs/openapi-spec/lend/lend.yaml)
 
 ---
 
@@ -192,8 +196,8 @@ Common error codes returned by `/swap/v2/execute` with recommended actions:
 - **Endpoints**: `/auth/challenge` (POST, body: `walletPubkey` + `type`), `/auth/verify` (POST, body: `type` + `walletPubkey` + base58 `signature`), `/vault` (GET), `/vault/register` (GET), `/deposit/craft` (POST), `/orders/price` (POST create, PATCH update), `/orders/price/cancel/{orderId}` (POST, initiates withdrawal), `/orders/price/confirm-cancel/{orderId}` (POST, submits signed withdrawal + `cancelRequestId`), `/orders/history` (GET, wallet implicit via JWT)
 - **Order types**: `single` (one directional trigger), `oco` (take-profit + stop-loss pair), `otoco` (entry trigger + OCO). `triggerCondition`: `"above"` or `"below"`.
 - **Architecture**: Off-chain custodial vault (Privy) per wallet. Orders invisible on-chain until execution — MEV-resistant. Triggers on USD price (not pool rate ratios). Partial fills supported.
-- **Gotchas**: Order creation is 3 steps — `GET /vault/register` (register if new), `POST /deposit/craft` (returns `transaction` + `requestId`), sign deposit tx, then `POST /orders/price` with `depositRequestId` + `depositSignedTx`. Cancellation is two-step — `POST /cancel/{orderId}` returns `transaction` + `requestId`; sign, then `POST /confirm-cancel/{orderId}` with `signedTransaction` + `cancelRequestId`. Response field is `id` (not `orderId`).
-- Refs: [Overview](https://developers.jup.ag/docs/trigger/index.md) | [Create order](https://developers.jup.ag/docs/trigger/create-order.md) | [Order history](https://developers.jup.ag/docs/trigger/order-history.md) | [Manage orders](https://developers.jup.ag/docs/trigger/manage-orders.md) | [OpenAPI](https://developers.jup.ag/docs/openapi-spec/trigger/v2/trigger.yaml)
+- **Gotchas**: Order creation is 3 steps — `GET /vault/register` (register if new; returns `409 "Vault already registered"` if it exists, which is fine), `POST /deposit/craft` (returns `transaction` + `requestId`; the body MUST include `orderType: "price"` and `orderSubType` (`single`/`oco`/`otoco`)), sign deposit tx, then `POST /orders/price` with `depositRequestId` + `depositSignedTx`. Cancellation is two-step — `POST /cancel/{orderId}` returns `transaction` + `requestId`; sign, then `POST /confirm-cancel/{orderId}` with `signedTransaction` + `cancelRequestId`. Create response field is `id` (not `orderId`); order history objects use `orderState`/`rawState` (no `status` field).
+- Refs: [Overview](https://developers.jup.ag/docs/trigger/index.md) | [Authentication](https://developers.jup.ag/docs/trigger/authentication.md) | [Create order](https://developers.jup.ag/docs/trigger/create-order.md) | [Order history](https://developers.jup.ag/docs/trigger/order-history.md) | [Manage orders](https://developers.jup.ag/docs/trigger/manage-orders.md) | [OpenAPI](https://developers.jup.ag/docs/openapi-spec/trigger/v2/trigger.yaml)
 
 ---
 
@@ -215,8 +219,8 @@ Common error codes returned by `/swap/v2/execute` with recommended actions:
 - **Base URL**: `https://api.jup.ag/tokens/v2`
 - **Triggers**: `token metadata`, `token search`, `shield`
 - **Endpoints**: `/search?query={q}` (GET, comma-separate mints, max 100), `/tag?query={tag}` (GET, `verified` or `lst`), `/{category}/{interval}` (GET, categories: `toporganicscore`, `toptraded`, `toptrending`; intervals: `5m`, `1h`, `6h`, `24h`), `/recent` (GET)
-- **Gotchas**: Use mint address as primary identity; treat symbol/name as convenience. Surface `audit.isSus` and `organicScore` in UX.
-- Refs: [Overview](https://developers.jup.ag/docs/tokens/index.md) | [Token info v2](https://developers.jup.ag/docs/tokens/v2/token-information.md) | [OpenAPI](https://developers.jup.ag/docs/openapi-spec/tokens/v2/tokens.yaml)
+- **Gotchas**: Use mint address as primary identity; treat symbol/name as convenience. Primary trust signal is top-level `isVerified` (boolean) plus `organicScore` (0-100) and `organicScoreLabel` (`high`/`medium`/`low`). Secondary risk flag: **`audit.isSus`** — a boolean present ONLY when `true` (a safe token has no `isSus` key at all), so check it defensively as `token.audit?.isSus === true`, never read it directly. Verified live on flagged tokens (dev holds ~100% of supply); those also carry `isVerified: null` and `organicScoreLabel: "low"`. Absence of `isSus` is NOT proof of safety — not all risky tokens carry the flag. Other conditional `audit` fields the live API returns: `mintAuthorityDisabled`, `freezeAuthorityDisabled`, `topHoldersPercentage`, `devBalancePercentage`, `devMigrations`, `devMints` (all nullable, any may be absent; `devMigrations` is returned but missing from the current OpenAPI schema).
+- Refs: [Overview](https://developers.jup.ag/docs/tokens/index.md) | [Token info v2](https://developers.jup.ag/docs/tokens/token-information.md) | [OpenAPI](https://developers.jup.ag/docs/openapi-spec/tokens/v2/tokens.yaml)
 
 ---
 
@@ -226,8 +230,9 @@ Common error codes returned by `/swap/v2/execute` with recommended actions:
 - **Triggers**: `price`, `valuation`, `price feed`
 - **Limit**: Max 50 mint IDs per request
 - **Endpoints**: `/price/v3?ids={mints}` (GET, comma-separated)
-- **Gotchas**: Tokens with unreliable pricing return `null` or are omitted (not an error). Fail closed on missing/low-confidence data for safety-sensitive actions. Use `confidenceLevel` field.
-- Refs: [Overview](https://developers.jup.ag/docs/price/index.md) | [Price v3](https://developers.jup.ag/docs/price/v3.md) | [OpenAPI](https://developers.jup.ag/docs/openapi-spec/price/v3/price.yaml)
+- **Response**: keyed by mint, each value has `usdPrice`, `blockId`, `decimals`, `priceChange24h`, `liquidity`, `createdAt` (some tokens add conditional fields like `launchpad`, `stockData`, `scaledUiConfig`). Price API V3 has NO `confidenceLevel` field (that was V2).
+- **Gotchas**: Tokens with unreliable pricing are omitted from the response entirely (not an error, no `null` placeholder). Fail closed when a requested mint is missing from the response for safety-sensitive actions. Use `blockId` to check price recency.
+- Refs: [Overview](https://developers.jup.ag/docs/price/index.md) | [OpenAPI](https://developers.jup.ag/docs/openapi-spec/price/v3/price.yaml)
 
 ---
 
@@ -250,8 +255,9 @@ Common error codes returned by `/swap/v2/execute` with recommended actions:
 - **Price convention**: 1,000,000 native units = $1.00 USD
 - **Triggers**: `prediction markets`, `market odds`, `event market`
 - **Deposit mints**: JupUSD (`JuprjznTrTSp2UFa3ZBUFgwdAmtZCq4MQCwysN55USD`), USDC
-- **Endpoints**: `/events` (GET), `/events/search` (GET), `/markets/{marketId}` (GET), `/orderbook/{marketId}` (GET), `/orders` (POST), `/orders/status/{pubkey}` (GET), `/positions` (GET), `/positions/{pubkey}` (DELETE), `/positions/{pubkey}/claim` (POST), `/history` (GET), `/leaderboards` (GET)
-- **Gotchas**: Check `position.claimable` before claiming. Winners get $1/contract.
+- **Min order**: $5 (5,000,000 native units)
+- **Endpoints**: `/events` (GET, returns `{data, pagination}`), `/events/search` (GET), `/markets/{marketId}` (GET), `/orderbook/{marketId}` (GET, returns `{yes, no, yes_dollars, no_dollars}`), `/orders` (POST, requires `isBuy` boolean + `ownerPubkey`), `/orders/status/{orderPubkey}` (GET), `/positions` (GET, `?ownerPubkey=`), `/positions/{positionPubkey}` (DELETE), `/positions/{positionPubkey}/claim` (POST), `/history` (GET), `/leaderboards` (GET)
+- **Gotchas**: Check `position.claimable` before claiming. Winners get $1/contract. Markets are FLAT (fields like `provider`, `marketId`, `result`, `resolveAt`, `outcomes`, `clobTokenIds` live at the top level, not nested under `metadata`). Contracts are fractional: use `contractsMicro` (1,000,000 = 1 contract) or `contractsDecimal`, not the legacy whole-number `contracts`.
 - Refs: [Overview](https://developers.jup.ag/docs/prediction/index.md) | [Events](https://developers.jup.ag/docs/prediction/events-and-markets.md) | [Positions](https://developers.jup.ag/docs/prediction/open-positions.md) | [OpenAPI](https://developers.jup.ag/docs/openapi-spec/prediction/prediction.yaml)
 
 ---
@@ -296,11 +302,11 @@ Common error codes returned by `/swap/v2/execute` with recommended actions:
 ### Routing
 
 - **Triggers**: `dex integration`, `rfq integration`, `routing engine`
-- **Engines**: Juno (meta-aggregator), Iris (multi-hop DEX routing, powers Swap API), JupiterZ (RFQ market maker quotes)
-- **DEX Integration** (into Iris): Free, no fees. Prereqs: code health, security audit, market traction. Implement `jupiter-amm-interface` crate. **Critical**: No network calls in implementation (accounts are pre-batched and cached). Ref impl: [github.com/jup-ag/rust-amm-implementation](https://github.com/jup-ag/rust-amm-implementation)
+- **Engines**: Juno (meta-aggregator), Metis (multi-hop DEX routing, powers the Swap API; formerly called Iris), JupiterZ (RFQ market maker quotes)
+- **DEX Integration** (into Metis): Free, no fees. Prereqs: code health, security audit, market traction. Implement `jupiter-amm-interface` crate. **Critical**: No network calls in implementation (accounts are pre-batched and cached). Ref impl: [github.com/jup-ag/rust-amm-implementation](https://github.com/jup-ag/rust-amm-implementation)
 - **RFQ Integration** (JupiterZ): Market makers host webhook at `/jupiter/rfq/quote` (POST, 250ms), `/jupiter/rfq/swap` (POST), `/jupiter/rfq/tokens` (GET). Reqs: 95% fill rate, 250ms response, 55s expiry. SDK: [github.com/jup-ag/rfq-webhook-toolkit](https://github.com/jup-ag/rfq-webhook-toolkit)
 - **Market Listing**: Instant routing for tokens < 30 days old. Normal routing (checked every 30 min) requires < 30% loss on $500 round-trip OR < 20% price impact comparing $1k vs $500.
-- Refs: [Overview](https://developers.jup.ag/docs/routing/index.md) | [DEX integration](https://developers.jup.ag/docs/routing/dex-integration.md) | [RFQ integration](https://developers.jup.ag/docs/routing/rfq-integration.md) | [Market listing](https://developers.jup.ag/docs/routing/market-listing.md)
+- Refs: [DEX integration](https://developers.jup.ag/docs/swap/routing/dex-integration.md) | [RFQ integration](https://developers.jup.ag/docs/swap/routing/rfq-integration.md) | [Market listing](https://developers.jup.ag/docs/swap/routing/market-listing.md)
 
 ---
 
@@ -317,7 +323,7 @@ Common error codes returned by `/swap/v2/execute` with recommended actions:
 
 Quotas recalculate every 10 minutes. Pro plan does NOT increase Swap API limits.
 
-**Other APIs**: Managed at portal level. Check [portal rate limits](https://developers.jup.ag/docs/portal/rate-limit.md).
+**Other APIs**: Managed at portal level. Check [portal rate limits](https://developers.jup.ag/docs/portal/rate-limits.md).
 
 **On HTTP 429**: Exponential backoff with jitter: `delay = min(baseDelay * 2^attempt + random(0, jitter), maxDelay)`. Wait for 10s sliding window refresh. Do NOT burst aggressively.
 
@@ -338,7 +344,7 @@ Quotas recalculate every 10 minutes. Pro plan does NOT increase Swap API limits.
 
 1. Start from the API-specific overview before coding endpoint calls.
 2. Enforce auth as a hard precondition for every request. Ref: [Portal setup](https://developers.jup.ag/docs/portal/setup.md)
-3. Design retry logic around documented rate-limit behavior, not fixed assumptions. Ref: [Rate limits](https://developers.jup.ag/docs/portal/rate-limit.md)
+3. Design retry logic around documented rate-limit behavior, not fixed assumptions. Ref: [Rate limits](https://developers.jup.ag/docs/portal/rate-limits.md)
 4. Map all non-success responses to typed app errors using documented response semantics. Ref: [API responses](https://developers.jup.ag/docs/portal/responses.md)
 5. For order-based products (Swap/Trigger/Recurring), separate create/execute/retrieve phases in code and logs.
 6. Treat network/service health as part of runtime behavior (degrade gracefully). Ref: [Status page](https://status.jup.ag/)
@@ -416,10 +422,10 @@ Always fetch the freshest context from referenced docs/specs before executing a 
 ## Operational References
 
 - [Portal setup](https://developers.jup.ag/docs/portal/setup.md) — API key configuration
-- [Rate limits](https://developers.jup.ag/docs/portal/rate-limit.md) — Global rate limit policy
-- [Swap routing](https://developers.jup.ag/docs/swap/v2/routing.md) — Router competition and parameter impact
+- [Rate limits](https://developers.jup.ag/docs/portal/rate-limits.md) — Global rate limit policy
+- [Swap overview](https://developers.jup.ag/docs/swap/index.md) — Router competition and parameter impact
 - [API responses](https://developers.jup.ag/docs/portal/responses.md) — Response format standards
-- [Swap order & execute](https://developers.jup.ag/docs/swap/v2/order-and-execute.md) — Detailed error codes and response format
+- [Swap order & execute](https://developers.jup.ag/docs/swap/order-and-execute.md) — Detailed error codes and response format
 - [Status page](https://status.jup.ag/) — Service health
 - [Documentation sitemap](https://developers.jup.ag/docs/llms.txt) — Full docs index
 - [Tool Kits](https://developers.jup.ag/docs/tool-kits/plugin/index.md) — Plugin, Wallet Kit, Referral Program

--- a/skills/integrating-jupiter/SKILL.md
+++ b/skills/integrating-jupiter/SKILL.md
@@ -4,7 +4,7 @@ description: Comprehensive guidance for integrating Jupiter APIs (Swap, Lend, Pe
 license: MIT
 metadata:
   author: jup-ag
-  version: "1.1.0"
+  version: "1.1.1"
 tags:
   - jupiter
   - jup-ag
@@ -131,9 +131,13 @@ Use each block as a minimal execution contract. Fetch the linked refs for full r
 - **Fee**: Variable by pair — 0 bps (Jupiter tokens/pegged), 2 bps (SOL-Stable), 5 bps (LST-Stable), 10 bps (most pairs), 50 bps (tokens < 24h). Referral fees: 50-255 bps (Jupiter retains 20%).
 - **Rate Limit**: 50 req/10s base, scales with 24h execute volume (see [Rate Limits](#rate-limits))
 - **Endpoints**: `/order` (GET), `/execute` (POST), `/build` (GET, Metis-only raw instructions)
-- **Routing**: 4 routers compete — Metis (`metis`), JupiterZ (`jupiterz`), Dflow (`dflow`), OKX (`okx`). The `router` response field returns one of these values (`metis`, not the legacy `iris`). `swapType` is `aggregator` (Metis, Dflow, or OKX) or `rfq` (JupiterZ). Response `mode` field: `"ultra"` (all routers, default params) or `"manual"` (restricted by optional params). `/build` uses Metis only.
+- **Routing**: 4 routers compete — Metis (`metis`), JupiterZ (`jupiterz`), Dflow (`dflow`), OKX (`okx`). The `router` response field returns one of these values. `swapType` is `aggregator` (Metis, Dflow, or OKX) or `rfq` (JupiterZ). Response `mode` field: `"ultra"` (all routers, default params) or `"manual"` (restricted by optional params). `/build` uses Metis only.
 - **Gasless**: Three paths — automatic (Jupiter-covered), JupiterZ (MM-covered), integrator-payer (`payer` param, Metis-only routing). Eligibility varies by balance, trade size, and parameters used. See [Gasless docs](https://developers.jup.ag/docs/swap/advanced/gasless.md) for current thresholds and disqualifying params.
-- **Gotchas**: Signed payloads have ~2 min TTL. Transactions are immutable after receipt. Split order/execute in code and logging. Re-quote before execution when conditions may have changed. Routing impact of optional params: `referralAccount` + `referralFee` disable JupiterZ only (Metis/Dflow/OKX remain); `payer` (integrator gasless) restricts routing to Metis only (disables JupiterZ, Dflow, and OKX); `receiver` does NOT restrict routing, but must differ from `taker` (`receiver=taker` returns `400 "Receiver cannot be same as taker"`). `/build` transactions cannot use `/execute` — self-manage via RPC.
+- **Gotchas**:
+  - Signed payloads have ~2 min TTL. Transactions are immutable after receipt.
+  - Split order/execute in code and logging. Re-quote before execution when conditions may have changed.
+  - Routing impact of optional params: `referralAccount` + `referralFee` disable JupiterZ only (Metis/Dflow/OKX remain); `payer` (integrator gasless) restricts routing to Metis only (disables JupiterZ, Dflow, and OKX); `receiver` does NOT restrict routing, but must differ from `taker` (`receiver=taker` returns `400 "Receiver cannot be same as taker"`).
+  - `/build` transactions cannot use `/execute` — self-manage via RPC.
 - **Migrating from an older integration?** Use the `jupiter-swap-migration` skill.
 - Refs: [Overview](https://developers.jup.ag/docs/swap/index.md) | [Order & Execute](https://developers.jup.ag/docs/swap/order-and-execute.md) | [Build](https://developers.jup.ag/docs/swap/build/index.md) | [Gasless](https://developers.jup.ag/docs/swap/advanced/gasless.md) | [Migration](https://developers.jup.ag/docs/swap/migration/ultra-to-order.md) | [OpenAPI](https://developers.jup.ag/docs/openapi-spec/swap/v2/swap.yaml)
 
@@ -196,7 +200,10 @@ On success, `/execute` returns `{ status: "Success", code: 0, signature, inputAm
 - **Endpoints**: `/auth/challenge` (POST, body: `walletPubkey` + `type`), `/auth/verify` (POST, body: `type` + `walletPubkey` + base58 `signature`), `/vault` (GET), `/vault/register` (GET), `/deposit/craft` (POST), `/orders/price` (POST create, PATCH update), `/orders/price/cancel/{orderId}` (POST, initiates withdrawal), `/orders/price/confirm-cancel/{orderId}` (POST, submits signed withdrawal + `cancelRequestId`), `/orders/history` (GET, wallet implicit via JWT)
 - **Order types**: `single` (one directional trigger), `oco` (take-profit + stop-loss pair), `otoco` (entry trigger + OCO). `triggerCondition`: `"above"` or `"below"`.
 - **Architecture**: Off-chain custodial vault (Privy) per wallet. Orders invisible on-chain until execution — MEV-resistant. Triggers on USD price (not pool rate ratios). Partial fills supported.
-- **Gotchas**: Order creation is 3 steps — `GET /vault/register` (register if new; returns `409 "Vault already registered"` if it exists, which is fine), `POST /deposit/craft` (returns `transaction` + `requestId`; the body MUST include `orderType: "price"` and `orderSubType` (`single`/`oco`/`otoco`)), sign deposit tx, then `POST /orders/price` with `depositRequestId` + `depositSignedTx`. Cancellation is two-step — `POST /cancel/{orderId}` returns `transaction` + `requestId`; sign, then `POST /confirm-cancel/{orderId}` with `signedTransaction` + `cancelRequestId`. Create response field is `id` (not `orderId`); order history objects use `orderState`/`rawState` (no `status` field).
+- **Gotchas**:
+  - Order creation is 3 steps — `GET /vault/register` (register if new; returns `409 "Vault already registered"` if it exists, which is fine), `POST /deposit/craft` (returns `transaction` + `requestId`; the body MUST include `orderType: "price"` and `orderSubType` (`single`/`oco`/`otoco`)), sign deposit tx, then `POST /orders/price` with `depositRequestId` + `depositSignedTx`.
+  - Cancellation is two-step — `POST /cancel/{orderId}` returns `transaction` + `requestId`; sign, then `POST /confirm-cancel/{orderId}` with `signedTransaction` + `cancelRequestId`.
+  - Create response field is `id` (not `orderId`); order history objects use `orderState`/`rawState` (no `status` field).
 - Refs: [Overview](https://developers.jup.ag/docs/trigger/index.md) | [Authentication](https://developers.jup.ag/docs/trigger/authentication.md) | [Create order](https://developers.jup.ag/docs/trigger/create-order.md) | [Order history](https://developers.jup.ag/docs/trigger/order-history.md) | [Manage orders](https://developers.jup.ag/docs/trigger/manage-orders.md) | [OpenAPI](https://developers.jup.ag/docs/openapi-spec/trigger/v2/trigger.yaml)
 
 ---
@@ -219,7 +226,11 @@ On success, `/execute` returns `{ status: "Success", code: 0, signature, inputAm
 - **Base URL**: `https://api.jup.ag/tokens/v2`
 - **Triggers**: `token metadata`, `token search`, `shield`
 - **Endpoints**: `/search?query={q}` (GET, comma-separate mints, max 100), `/tag?query={tag}` (GET, `verified` or `lst`), `/{category}/{interval}` (GET, categories: `toporganicscore`, `toptraded`, `toptrending`; intervals: `5m`, `1h`, `6h`, `24h`), `/recent` (GET)
-- **Gotchas**: Use mint address as primary identity; treat symbol/name as convenience. Primary trust signal is top-level `isVerified` (boolean) plus `organicScore` (0-100) and `organicScoreLabel` (`high`/`medium`/`low`). Secondary risk flag: **`audit.isSus`** — a boolean present ONLY when `true` (a safe token has no `isSus` key at all), so check it defensively as `token.audit?.isSus === true`, never read it directly. Verified live on flagged tokens (dev holds ~100% of supply); those also carry `isVerified: null` and `organicScoreLabel: "low"`. Absence of `isSus` is NOT proof of safety — not all risky tokens carry the flag. Other conditional `audit` fields the live API returns: `mintAuthorityDisabled`, `freezeAuthorityDisabled`, `topHoldersPercentage`, `devBalancePercentage`, `devMigrations`, `devMints` (all nullable, any may be absent; `devMigrations` is returned but missing from the current OpenAPI schema).
+- **Gotchas**:
+  - Use mint address as primary identity; treat symbol/name as convenience.
+  - Primary trust signal is top-level `isVerified` (boolean) plus `organicScore` (0-100) and `organicScoreLabel` (`high`/`medium`/`low`).
+  - Secondary risk flag: **`audit.isSus`** — a boolean present ONLY when `true` (a safe token has no `isSus` key at all), so check it defensively as `token.audit?.isSus === true`, never read it directly. Verified live on flagged tokens (dev holds ~100% of supply); those also carry `isVerified: null` and `organicScoreLabel: "low"`. Absence of `isSus` is NOT proof of safety — not all risky tokens carry the flag.
+  - Other conditional `audit` fields the live API returns: `mintAuthorityDisabled`, `freezeAuthorityDisabled`, `topHoldersPercentage`, `devBalancePercentage`, `devMigrations`, `devMints` (all nullable, any may be absent; `devMigrations` is returned but missing from the current OpenAPI schema).
 - Refs: [Overview](https://developers.jup.ag/docs/tokens/index.md) | [Token info v2](https://developers.jup.ag/docs/tokens/token-information.md) | [OpenAPI](https://developers.jup.ag/docs/openapi-spec/tokens/v2/tokens.yaml)
 
 ---
@@ -257,7 +268,10 @@ On success, `/execute` returns `{ status: "Success", code: 0, signature, inputAm
 - **Deposit mints**: JupUSD (`JuprjznTrTSp2UFa3ZBUFgwdAmtZCq4MQCwysN55USD`), USDC
 - **Min order**: $5 (5,000,000 native units)
 - **Endpoints**: `/events` (GET, returns `{data, pagination}`), `/events/search` (GET), `/markets/{marketId}` (GET), `/orderbook/{marketId}` (GET, returns `{yes, no, yes_dollars, no_dollars}`), `/orders` (POST, requires `isBuy` boolean + `ownerPubkey`), `/orders/status/{orderPubkey}` (GET), `/positions` (GET, `?ownerPubkey=`), `/positions/{positionPubkey}` (DELETE), `/positions/{positionPubkey}/claim` (POST), `/history` (GET), `/leaderboards` (GET)
-- **Gotchas**: Check `position.claimable` before claiming. Winners get $1/contract. Markets are FLAT (fields like `provider`, `marketId`, `result`, `resolveAt`, `outcomes`, `clobTokenIds` live at the top level, not nested under `metadata`). Contracts are fractional: use `contractsMicro` (1,000,000 = 1 contract) or `contractsDecimal`, not the legacy whole-number `contracts`.
+- **Gotchas**:
+  - Check `position.claimable` before claiming. Winners get $1/contract.
+  - Markets are FLAT — fields like `provider`, `marketId`, `result`, `resolveAt`, `outcomes`, `clobTokenIds` live at the top level, not nested under `metadata`.
+  - Contracts are fractional: use `contractsMicro` (1,000,000 = 1 contract) or `contractsDecimal`, not the legacy whole-number `contracts`.
 - Refs: [Overview](https://developers.jup.ag/docs/prediction/index.md) | [Events](https://developers.jup.ag/docs/prediction/events-and-markets.md) | [Positions](https://developers.jup.ag/docs/prediction/open-positions.md) | [OpenAPI](https://developers.jup.ag/docs/openapi-spec/prediction/prediction.yaml)
 
 ---

--- a/skills/integrating-jupiter/examples/price.md
+++ b/skills/integrating-jupiter/examples/price.md
@@ -14,35 +14,35 @@ const SOL_MINT = 'So11111111111111111111111111111111111111112';
 const USDC_MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
 const WBTC_MINT = '3NZ9JMVBmGAqocybic2c7LQCJScmgsAZ6vQqTDzcqmJh';
 
-async function getPrices(mints: string[], confidenceLevel: 'low' | 'medium' | 'high' = 'medium') {
-  const ids = mints.join(',');
+// Price API V3 response is keyed by mint. Each entry has usdPrice (number),
+// blockId, decimals, priceChange24h, and liquidity. There is NO confidenceLevel
+// field (that was V2). Mints with no reliable price are OMITTED from the
+// response entirely — there is no null placeholder — so treat a missing mint
+// as "unpriced" and fail closed for safety-sensitive actions.
+type PriceEntry = {
+  usdPrice: number;
+  blockId: number;
+  decimals: number;
+  priceChange24h: number;
+  liquidity?: number;
+};
 
-  const data = await jupiterFetch<{
-    data: Record<string, { price: string; confidenceLevel?: string } | null>;
-  }>(`/price/v3?ids=${encodeURIComponent(ids)}`);
+async function getPrices(mints: string[]) {
+  const ids = mints.join(','); // max 50 mints per request
 
-  const prices: Record<string, { price: number; confidence: string } | null> = {};
+  const data = await jupiterFetch<Record<string, PriceEntry>>(
+    `/price/v3?ids=${encodeURIComponent(ids)}`,
+  );
 
+  const prices: Record<string, PriceEntry | null> = {};
   for (const mint of mints) {
-    const entry = data.data?.[mint];
-    if (!entry || !entry.price) {
-      prices[mint] = null; // token not priced or unreliable
-      continue;
-    }
-
-    // Filter by confidence — fail closed on low-confidence data
-    const levels = ['low', 'medium', 'high'];
-    const entryLevel = entry.confidenceLevel || 'low';
-    if (levels.indexOf(entryLevel) < levels.indexOf(confidenceLevel)) {
-      prices[mint] = null;
-      continue;
-    }
-
-    prices[mint] = { price: parseFloat(entry.price), confidence: entryLevel };
+    // Missing mint => no reliable price. Fail closed.
+    prices[mint] = data[mint] ?? null;
   }
-
   return prices;
 }
 
-// Usage: getPrices([SOL_MINT, USDC_MINT, WBTC_MINT])
+// Usage:
+// const prices = await getPrices([SOL_MINT, USDC_MINT, WBTC_MINT]);
+// const solUsd = prices[SOL_MINT]?.usdPrice; // number | undefined
 ```

--- a/skills/integrating-jupiter/examples/trigger.md
+++ b/skills/integrating-jupiter/examples/trigger.md
@@ -93,6 +93,8 @@ async function craftDeposit(jwt: string, inputMint: string, amount: string) {
       outputMint: USDC_MINT,    // destination token for the order
       userAddress: wallet.publicKey.toBase58(),
       amount,
+      orderType: 'price',       // required
+      orderSubType: 'single',   // required: match the order you will create (single | oco | otoco)
     }),
   });
 

--- a/skills/jupiter-lend/SKILL.md
+++ b/skills/jupiter-lend/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: jupiter-lend
-version: 0.1.2
+version: 0.1.3
 description: Interact with Jupiter Lend Protocol. Read-only SDK (@jup-ag/lend-read) for querying liquidity pools, lending markets (jlTokens), and vaults. Write SDK (@jup-ag/lend) for lending (deposit/withdraw) and vault operations (deposit collateral, borrow, repay, manage positions).
 homepage: https://jup.ag/lend
 metadata:
@@ -359,9 +359,9 @@ The Jupiter Lend Build Kit offers developer components, powerful utilities, and 
 - **Wallet integrations (Privy)**: [Earn with Privy](https://developers.jup.ag/docs/lend/wallets/privy-earn), [Borrow with Privy](https://developers.jup.ag/docs/lend/wallets/privy-borrow)
 - **Borrow**: [overview](https://developers.jup.ag/docs/lend/borrow), [create position](https://developers.jup.ag/docs/lend/borrow/create-position), [deposit](https://developers.jup.ag/docs/lend/borrow/deposit), [borrow](https://developers.jup.ag/docs/lend/borrow/borrow), [repay](https://developers.jup.ag/docs/lend/borrow/repay), [withdraw](https://developers.jup.ag/docs/lend/borrow/withdraw), [combined operate](https://developers.jup.ag/docs/lend/borrow/combined), [liquidate](https://developers.jup.ag/docs/lend/borrow/liquidation), [read vault data](https://developers.jup.ag/docs/lend/borrow/read-vault-data)
 - **Flashloan**: [overview](https://developers.jup.ag/docs/lend/flashloan), [execute](https://developers.jup.ag/docs/lend/flashloan/execute)
-- **Advanced**: [advanced/multiply](https://developers.jup.ag/docs/lend/advanced/multiply), [advanced/unwind](https://developers.jup.ag/docs/lend/advanced/unwind), [advanced/repay-withdraw-collateral](https://developers.jup.ag/docs/lend/advanced/repay-with-collateral-max-withdraw), [advanced/vault-swap](https://developers.jup.ag/docs/lend/advanced/vault-swap), [advanced/utilization-after-deposit](https://developers.jup.ag/docs/lend/advanced/utilization-after-deposit), [advanced/native-staked-vault/overview](https://developers.jup.ag/docs/lend/advanced/native-staked-vault/overview), [advanced/native-staked-vault/deposit](https://developers.jup.ag/docs/lend/advanced/native-staked-vault/deposit), [advanced/native-staked-vault/withdraw](https://developers.jup.ag/docs/lend/advanced/native-staked-vault/withdraw)
+- **Advanced**: [advanced/multiply](https://developers.jup.ag/docs/lend/advanced/multiply), [advanced/unwind](https://developers.jup.ag/docs/lend/advanced/unwind), [advanced/repay-withdraw-collateral](https://developers.jup.ag/docs/lend/advanced/repay-with-collateral-max-withdraw), [advanced/vault-swap](https://developers.jup.ag/docs/lend/advanced/vault-swap), [advanced/utilization-after-deposit](https://developers.jup.ag/docs/lend/advanced/utilization-after-deposit), [advanced/native-staked-vault/overview](https://developers.jup.ag/docs/lend/advanced/native-staked-vault), [advanced/native-staked-vault/deposit](https://developers.jup.ag/docs/lend/advanced/native-staked-vault/deposit), [advanced/native-staked-vault/withdraw](https://developers.jup.ag/docs/lend/advanced/native-staked-vault/withdraw)
 - **Liquidity**: [liquidity/analytics](https://developers.jup.ag/docs/lend/liquidity/analytics)
-- **Resources**: [resources/program-addresses](https://developers.jup.ag/docs/lend/resources/program-addresses), [resources/idl-and-types](https://developers.jup.ag/docs/lend/resources/idl-and-types), [resources/dune](https://developers.jup.ag/docs/lend/resources/dune)
+- **Resources**: [resources/program-addresses](https://developers.jup.ag/docs/lend/program-addresses), [resources/idl-and-types](https://developers.jup.ag/docs/lend/idl-and-types), [resources/dune](https://developers.jup.ag/docs/lend/dune)
 
 ---
 

--- a/skills/jupiter-swap-migration/SKILL.md
+++ b/skills/jupiter-swap-migration/SKILL.md
@@ -4,7 +4,7 @@ description: Migration guide from Jupiter Metis (v1) or Ultra to Swap API v2. Us
 license: MIT
 metadata:
   author: jup-ag
-  version: "1.0.0"
+  version: "1.1.0"
 tags:
   - jupiter
   - swap-migration
@@ -64,7 +64,7 @@ Each path has a dedicated example with before/after code, parameter mappings, an
 6. **ALT handling**: If using `/build`, switch from `addressLookupTableAddresses` (array) to `addressesByLookupTableAddress` (object) — remove RPC ALT resolution code
 7. **Fee event parsing**: V2 instructions don't emit fee events — update any transaction parser that depends on them
 8. **Route plan format**: If parsing route plans, use `bps` field (canonical) instead of `percent`
-9. **Error codes**: Update error handling to match [Swap v2 error codes](https://developers.jup.ag/docs/swap/v2/order-and-execute.md)
+9. **Error codes**: Update error handling to match [Swap v2 error codes](https://developers.jup.ag/docs/swap/order-and-execute.md)
 10. **Test**: Run end-to-end swap on devnet/mainnet with small amount to verify
 
 ## Sunset
@@ -75,9 +75,12 @@ Remove this skill once Jupiter decommissions the v1 (`/swap/v1`) endpoints and t
 
 ## References
 
-- [Migration guide](https://developers.jup.ag/docs/swap/v2/migration.md)
-- [Order & Execute](https://developers.jup.ag/docs/swap/v2/order-and-execute.md)
-- [Build](https://developers.jup.ag/docs/swap/v2/build/index.md)
-- [Fees](https://developers.jup.ag/docs/swap/v2/fees.md)
-- [Routing](https://developers.jup.ag/docs/swap/v2/routing.md)
+Migration is split into three profile-targeted guides (the old single `migration` page no longer exists):
+
+- [Migration: Ultra → /order](https://developers.jup.ag/docs/swap/migration/ultra-to-order.md)
+- [Migration: Metis → /build](https://developers.jup.ag/docs/swap/migration/metis-to-build.md)
+- [Migration: Metis → Meta-Aggregator (/order + /execute)](https://developers.jup.ag/docs/swap/migration/metis-to-meta-aggregator.md)
+- [Order & Execute](https://developers.jup.ag/docs/swap/order-and-execute.md)
+- [Build](https://developers.jup.ag/docs/swap/build/index.md)
+- [Swap overview](https://developers.jup.ag/docs/swap/index.md) (routing and fees)
 - [OpenAPI spec](https://developers.jup.ag/docs/openapi-spec/swap/v2/swap.yaml)

--- a/skills/jupiter-swap-migration/examples/ultra-to-order.md
+++ b/skills/jupiter-swap-migration/examples/ultra-to-order.md
@@ -53,7 +53,7 @@ const result = await fetch(`${BASE_URL}/execute`, {
 ## New response fields
 
 The v2 `/order` response now also includes:
-- `router` — which router won: `"iris"`, `"jupiterz"`, `"dflow"`, or `"okx"`
+- `router` — which router won: `"metis"`, `"jupiterz"`, `"dflow"`, or `"okx"`
 - `mode` — `"ultra"` (all routers competed) or `"manual"` (optional params restricted routing)
 - `feeBps` — fee basis points applied
 - `feeMint` — mint of the fee token


### PR DESCRIPTION
## Summary

Refreshes all four skills in the `integrate-jupiter` plugin to match the current Jupiter docs and live API. Skill content was last meaningfully updated 2026-03-27 (Swap V2 migration); the docs have drifted since. **Every claim was verified against the live production API** — not just a 200 status, but the actual response shape. Source edits live in `skills/*`; `scripts/sync_plugin_skills.sh` regenerated the Claude + Codex plugin copies (verified byte-identical).

## How it was verified

Live, with a funded test wallet + production API key:

- **Swap** — ran a real USDC→SOL swap end-to-end (`/order` → sign → `/execute` → on-chain confirm); output matched the quote exactly.
- **Trigger** — ran the full order lifecycle on-chain (auth → vault → deposit → create → cancel → confirm-cancel); funds reclaimed.
- **Fee tiers** — quoted representative pairs: USDC→USDT `0bps` (pegged), SOL→USDC `2bps`, jitoSOL/mSOL→USDC `5bps` (LST), JUP/SOL→BONK `10bps`, SOL→JUP `0bps` (Jupiter token).
- **Lend** — all 9 earn endpoints return the documented shapes.
- **Recurring** — constraints confirmed via live rejections (min 2 orders, min $50/order); a valid order builds a tx.
- **Tokens / Price / Portfolio / Send / Studio / Prediction** — every endpoint hit live; response shapes, required fields, and limits confirmed. **Perps** returns 404 (no REST API, as documented).
- All **86 doc links** validated against the docs repo filesystem (not just HTTP redirects).

## Key corrections

- **`iris` → `metis`** — router value, engine name, tag, README, migration example. Live `router` returns `metis`; `iris` has 0 refs left in docs.
- **`swapType`** — `aggregator` covers Metis, Dflow, and OKX; `rfq` is JupiterZ (verified live).
- **Gasless routing impact** — `receiver` does NOT restrict routing (only `referralAccount`+`referralFee` and `payer` do); `receiver` must differ from `taker` (`400` otherwise).
- **Price V3** — removed `confidenceLevel` (a V2-only field; not in V3 schema or responses); unpriced mints are omitted; rewrote `price.md` to the real mint-keyed `usdPrice` shape.
- **Tokens trust signals** — primary is `isVerified` + `organicScore`/`organicScoreLabel`. Documented `audit.isSus` precisely (verified live on flagged tokens): it's a boolean **present only when `true`** (absent for safe tokens), so check it defensively as `token.audit?.isSus === true`; absence is not proof of safety. Listed the `audit` sub-fields the live API actually returns, including `devMigrations` (which is **missing from the current OpenAPI schema**).
- **Trigger** — `deposit/craft` now requires `orderType` + `orderSubType`; history objects use `orderState`/`rawState`; documented the `409` vault-already-registered case.
- **`/execute` response** — documented `slot`, `totalInputAmount`, `totalOutputAmount`.
- **Doc links** — dropped the `/v2/` path prefix; migration is now 3 pages; lend `resources/*` moved to top level; `portal/rate-limit` → `portal/rate-limits`.

## Files

- `skills/integrating-jupiter/{SKILL.md, README.md, examples/price.md, examples/trigger.md}`
- `skills/jupiter-swap-migration/{SKILL.md, examples/ultra-to-order.md}`
- `skills/jupiter-lend/SKILL.md`
- `.plugins/integrate-jupiter/{claude,codex}/**` (regenerated via sync script)
- Skill + plugin version bumps

## Linear

- [DEV-281](https://linear.app/raccoons/issue/DEV-281/add-to-cli-skills-etc) — Add to CLI, skills, etc (Swap V2 / PM / Trigger)

## Spec drift surfaced during verification

The Tokens v2 `audit` object returns `devMigrations` on most tokens, but that field is **missing from the OpenAPI schema** (`openapi-spec/tokens/v2/tokens.yaml`). Worth a follow-up to add it to the spec. (The docs' `audit.isSus` guidance is correct — `isSus` is a real, present-when-flagged field.)
