### PR TITLE
docs: fix 404 Lend Earn API reference link

### DIFF
--- a/.plugins/integrate-jupiter/claude/skills/jupiter-lend/SKILL.md
+++ b/.plugins/integrate-jupiter/claude/skills/jupiter-lend/SKILL.md
@@ -570,7 +570,7 @@ main().catch(console.error);
 ## API Documentation
 
 - **Jupiter Lend Overview**: [developers.jup.ag/docs/lend](https://developers.jup.ag/docs/lend)
-- **Lend API (Earn)**: [api-reference/lend/earn](https://developers.jup.ag/api-reference/lend/earn) | REST API for Earn operations (deposit/withdraw/mint/redeem, tokens, positions, earnings)
+- **Lend API (Earn)**: [docs/lend/earn/api](https://dev.jup.ag/docs/lend/earn/api) | REST API for Earn operations (deposit/withdraw/mint/redeem, tokens, positions, earnings)
 - **Lend API (Borrow)**: *(Coming Soon)*
 
 ## SDKs

--- a/.plugins/integrate-jupiter/codex/skills/jupiter-lend/SKILL.md
+++ b/.plugins/integrate-jupiter/codex/skills/jupiter-lend/SKILL.md
@@ -570,7 +570,7 @@ main().catch(console.error);
 ## API Documentation
 
 - **Jupiter Lend Overview**: [developers.jup.ag/docs/lend](https://developers.jup.ag/docs/lend)
-- **Lend API (Earn)**: [api-reference/lend/earn](https://developers.jup.ag/api-reference/lend/earn) | REST API for Earn operations (deposit/withdraw/mint/redeem, tokens, positions, earnings)
+- **Lend API (Earn)**: [docs/lend/earn/api](https://dev.jup.ag/docs/lend/earn/api) | REST API for Earn operations (deposit/withdraw/mint/redeem, tokens, positions, earnings)
 - **Lend API (Borrow)**: *(Coming Soon)*
 
 ## SDKs

--- a/skills/jupiter-lend/SKILL.md
+++ b/skills/jupiter-lend/SKILL.md
@@ -570,7 +570,7 @@ main().catch(console.error);
 ## API Documentation
 
 - **Jupiter Lend Overview**: [developers.jup.ag/docs/lend](https://developers.jup.ag/docs/lend)
-- **Lend API (Earn)**: [api-reference/lend/earn](https://developers.jup.ag/api-reference/lend/earn) | REST API for Earn operations (deposit/withdraw/mint/redeem, tokens, positions, earnings)
+- **Lend API (Earn)**: [docs/lend/earn/api](https://dev.jup.ag/docs/lend/earn/api) | REST API for Earn operations (deposit/withdraw/mint/redeem, tokens, positions, earnings)
 - **Lend API (Borrow)**: *(Coming Soon)*
 
 ## SDKs


### PR DESCRIPTION
`skills/jupiter-lend/SKILL.md` links the Earn REST API reference to `https://developers.jup.ag/api-reference/lend/earn`, which returns 404. The reference now lives at [`https://dev.jup.ag/docs/lend/earn/api`](https://dev.jup.ag/docs/lend/earn/api) (200).

Since agents consume these skills verbatim, a dead API-reference URL sends them to nothing.

I edited `skills/` and regenerated the packaged copies with `scripts/sync_plugin_skills.sh --provider both`, so the two `.plugins/` files are script output rather than hand edits. The script touched only these three files.

**One I did not fix, because I could not confirm the right target:** `skills/integrating-jupiter/SKILL.md` line 317 lists `**Source**: https://github.com/jup-ag/jup-lock`, which also 404s. The closest surviving repos are `jup-ag/lock-sdk` (empty README, last touched April 2025) and `jup-ag/jup-lock-starter` (a Tanstack Start template), and neither looks like the program source that line means. If you tell me which it should be, I'll add it here.